### PR TITLE
docs: Replace dated styling/Mark systemctl command

### DIFF
--- a/docs/Branding.asciidoc
+++ b/docs/Branding.asciidoc
@@ -8,14 +8,14 @@
 
 You can alter the appearance of the openQA web UI to some extent through
 the 'branding' mechanism. The 'branding' configuration setting in the
-'global' section of +/etc/openqa/openqa.ini+ specifies the branding to
+'global' section of `/etc/openqa/openqa.ini` specifies the branding to
 use. It defaults to 'openSUSE', and openQA also includes the 'plain'
 branding, which is - as its name suggests - plain and generic.
 
 To create your own branding for openQA, you can create a subdirectory
-of +/usr/share/openqa/templates/branding+ (or wherever openQA is
+of `/usr/share/openqa/templates/branding` (or wherever openQA is
 installed). The subdirectory's name will be the name of your branding.
-You can copy the files from +branding/openSUSE+ or +branding/plain+ to
+You can copy the files from `branding/openSUSE` or `branding/plain` to
 use as starting points, and adjust as necessary.
 
 == Web UI template
@@ -26,8 +26,8 @@ use as starting points, and adjust as necessary.
 openQA uses the {mojo-website} framework's templating
 system; the branding files are included into the openQA templates at
 various points. To see where each branding file is actually included,
-you can search through the files in the +templates+ tree for the text
-+include_branding+. Anywhere that helper is called, the branding file
+you can search through the files in the `templates` tree for the text
+`include_branding`. Anywhere that helper is called, the branding file
 with the matching name is being included.
 
 The branding files themselves are Mojolicious 'Embedded Perl' templates just

--- a/docs/Contributing.asciidoc
+++ b/docs/Contributing.asciidoc
@@ -38,7 +38,7 @@ repositories can be found.
     - documentation
     - miscellaneous support scripts
 * test distribution: e.g. https://github.com/os-autoinst/os-autoinst-distri-opensuse for openSUSE
-    - the actual tests, in case of +os-autoinst-distri-opensuse+ conducted on http://openqa.opensuse.org
+    - the actual tests, in case of `os-autoinst-distri-opensuse` conducted on http://openqa.opensuse.org
 * needles: e.g. https://github.com/os-autoinst/os-autoinst-needles-opensuse for openSUSE
     - reference images if not already included in the test distribution
 * empty example test distribution: https://github.com/os-autoinst/os-autoinst-distri-example
@@ -73,7 +73,7 @@ for style checks, unit and integration tests.
 
 To execute a single test, one can tweak the test execution with the variables
 in the Makefile or use `prove` after pointing to a local test database in the
-environment variable +TEST_PG+. Also, If you set a custom base directory, be
+environment variable `TEST_PG`. Also, If you set a custom base directory, be
 sure to unset it when running tests.
 
 Example:
@@ -100,7 +100,7 @@ env CHECKSTYLE=0 PROVE_ARGS=t/24-worker-engine.t make coverage
 ----
 
 and take a look into the generated coverage HTML report in
-+cover_db/coverage.html+.
+`cover_db/coverage.html`.
 
 We use annotations in some places to mark "uncoverable" code such as this:
 
@@ -150,7 +150,7 @@ expected to be backed with the corresponding tests.
 == Technologies
 [id="technologies"]
 
-Everything in openQA, from +os-autoinst+ to the web frontend and from the tests
+Everything in openQA, from `os-autoinst` to the web frontend and from the tests
 to the support scripts is written in Perl. So having some basic knowledge
 about that language is really desirable in order to understand and develop
 openQA. Of course, in addition to bare Perl, several libraries and additional
@@ -159,7 +159,7 @@ using the available os-autoinst and openQA packages, as described in the
 Installation Guide.
 
 In the case of os-autoinst, only a few http://www.cpan.org/[CPAN] modules are
-required. Basically +Carp::Always+, +Data::Dump+. +JSON+ and +YAML+. On the other
+required. Basically `Carp::Always`, `Data::Dump`. `JSON` and `YAML`. On the other
 hand, several external tools are needed including
 http://wiki.qemu.org/Main_Page[QEMU],
 https://code.google.com/p/tesseract-ocr/[Tesseract] and
@@ -174,7 +174,7 @@ documentation available at its http://mojolicio.us[home page].
 
 In addition to Mojolicious and its dependencies, several other CPAN modules are
 required by the openQA package. For a full list of hard dependencies, see the
-file +cpanfile+ at the root of the openQA repository.
+file `cpanfile` at the root of the openQA repository.
 
 openQA relies on PostgreSQL to store the information. It used to support SQLite,
 but that is no longer possible.
@@ -182,7 +182,7 @@ but that is no longer possible.
 As stated in the previous section, every feature implemented in both packages
 should be backed by proper tests.
 http://perldoc.perl.org/Test/More.html[Test::More] is used to implement those
-tests. As usual, tests are located under the +/t/+ directory. In the openQA
+tests. As usual, tests are located under the `/t/` directory. In the openQA
 package, one of the tests consists of a call to
 http://perltidy.sourceforge.net/[Perltidy] to ensure that the contributed code
 follows the most common Perl style conventions.
@@ -196,9 +196,9 @@ This section should give you a general idea how to do that. For a concrete examp
 use under openSUSE Tumbleweed have a look at the https://github.com/Martchus/openQA-helper[openQA-helper repository].
 
 === Dependencies
-Have a look at the packaged version (e.g. +openQA.spec+ within the root of the openQA repository)
+Have a look at the packaged version (e.g. `openQA.spec` within the root of the openQA repository)
 for all required dependencies. For development build time dependencies need to be installed as well.
-Recommended dependencies such logrotate can be ignored. For openSUSE there is also the +openQA-devel+
+Recommended dependencies such logrotate can be ignored. For openSUSE there is also the `openQA-devel`
 meta-package which pulls all required dependencies for development.
 
 [[setup-postgresql]]
@@ -221,20 +221,20 @@ One also needs to setup a PostgreSQL database for openQA manually owned by your 
 ==== Importing production data
 Assuming you have already followed steps 1. to 4. above:
 
-1. Create a separate database: `createdb -O your_username openqa-o3` where `openqa-o3` is
+1. Create a separate database: `createdb -O your_username openqa-o3+ where `openqa-o3+ is
    the name you want to use for the database
 2. The next steps must be done by the user you start your local openQA instance with.
 3. Import dump: `pg_restore -c -d openqa path/to/dump`
 4. Configure openQA to use that database as in step 7. above.
 
 === Starting daemons
-To start the webserver for development, use the +scripts/openqa daemon+. The other daemons (mentioned in
+To start the webserver for development, use the `scripts/openqa daemon`. The other daemons (mentioned in
 the link:images/architecture.svg[architecture diagram]) are started in the same way,
-e.g. +script/openqa-scheduler daemon+.
+e.g. `script/openqa-scheduler daemon`.
 
 You can also have a look at the systemd unit files. Although it likely makes not much sense to use them directly
-you can have a look at them to see how the different daemons are started. They are found in the +systemd+ directory
-of the openQA repository. You can substitute +/usr/share/openqa/+ with the path of your openQA Git checkout.
+you can have a look at them to see how the different daemons are started. They are found in the `systemd` directory
+of the openQA repository. You can substitute `/usr/share/openqa/` with the path of your openQA Git checkout.
 
 Of course you can ignore the user specified in these unit files and instead start everything as your
 regular user. However, you need to ensure that your user has the permission to the "openQA base directory".
@@ -245,8 +245,8 @@ This might take a while and requires an internet connection.
 
 You do *not* need to setup an additional web server because the daemons already provide one. The port
 under which a service is available is logged on startup (the main web UI port is 9625 by default). Local
-workers need to be configured to connect to the main web UI port (add +HOST = http://localhost:9526+ to
-+workers.ini+).
+workers need to be configured to connect to the main web UI port (add `HOST = http://localhost:9526+ to
+`workers.ini`).
 
 ==== Further tips
 * It is also useful to start openQA with morbo which allows applying changes
@@ -255,18 +255,18 @@ workers need to be configured to connect to the main web UI port (add +HOST = ht
     -l http://localhost:9526 script/openqa daemon`
 * In case you have problems with broken rendering of the web page it can help
   to delete the asset cache and let the webserver regenerate it on first
-  startup. For this delete the subdirectories +.sass-cache/+, +assets/cache/+
-  and +assets/assetpack.db+. Make sure to look for error messages on startup
+  startup. For this delete the subdirectories `.sass-cache/`, `assets/cache/`
+  and `assets/assetpack.db`. Make sure to look for error messages on startup
   of the webserver and to force the refresh of the web page in your browser.
 
 == Handling of dependencies
-* Add 3rd party JavaScript and CSS file to +assets/assetpack.def+. When restarting
+* Add 3rd party JavaScript and CSS file to `assets/assetpack.def`. When restarting
   the web server the new/updated files are pulled automatically. Also take care to
   <<Contributing.asciidoc#update-asset-cache,update the asset cache for the openSUSE RPM package>>.
-* Other dependencies need to be added to +openQA.spec+ or +os-autoinst.spec+.
-* Perl dependencies need to be added *additionally* to +cpanfile+.
+* Other dependencies need to be added to `openQA.spec` or `os-autoinst.spec`.
+* Perl dependencies need to be added *additionally* to `cpanfile`.
 * To easily get all necessary dependencies on openSUSE you can install the
-  package +openQA-devel+. In other cases one can rely on the +cpanfile+ and
+  package `openQA-devel`. In other cases one can rely on the `cpanfile` and
   read out the dependencies from the spec file for the rest.
 
 === Remarks
@@ -275,18 +275,18 @@ workers need to be configured to connect to the main web UI port (add +HOST = ht
   build of that container must not be broken (see
   https://build.opensuse.org/package/show/devel:openQA/openQA[build results on OBS]).
 * The os-autoinst repository uses the container made using
-  +docker/travis_test/Dockerfile+ within the openQA repository.
+  `docker/travis_test/Dockerfile` within the openQA repository.
 
 [[update-asset-cache]]
 === Update asset cache for openSUSE RPM package
 1. Clone the repository (or a branch to it if you do not have the rights to push directly)
-   locally, e.g. +osc co devel:openQA/openQA+.
-2. Run +bash update-cache.sh+ inside the repository folder. Follow the log checking no
+   locally, e.g. `osc co devel:openQA/openQA`.
+2. Run `bash update-cache.sh` inside the repository folder. Follow the log checking no
    download errors occurred.
-3. Do a sanity check on the generated +cache.txz+. It usually should not be smaller than
+3. Do a sanity check on the generated `cache.txz`. It usually should not be smaller than
    before, contain the newly added sources and must not contain any empty files.
-4. Add an entry to the changes file using +osc vc openQA.changes+.
-5. +osc ci -m 'Update asset cache'+
+4. Add an entry to the changes file using `osc vc openQA.changes`.
+5. `osc ci -m 'Update asset cache'`
 
 == Managing the database
 
@@ -296,9 +296,9 @@ there are some steps that have to be followed so that new database instances
 and upgrades include those changes.
 
 === When is it required to update the database schema?
-After modifying files in +lib/OpenQA/Schema/Result+. However, not all changes
+After modifying files in `lib/OpenQA/Schema/Result`. However, not all changes
 require to update the schema. Adding just another method or altering/adding
-functions like +has_many+ doesn't require an update. However, adding new
+functions like `has_many` doesn't require an update. However, adding new
 columns, modifying or removing existing ones requires to follow the steps
 mentioned above. In doubt, just follow the instructions below. If an empty
 migration has been emitted (SQL file produced in step 3. does not contain
@@ -307,7 +307,7 @@ any statements) you can just drop the migration again.
 === How to update the database schema
 
 1. First, you need to increase the database version number in the `$VERSION`
-   variable in the +lib/OpenQA/Schema.pm+ file.
+   variable in the `lib/OpenQA/Schema.pm` file.
    Note that it is recommended to notify the other developers before doing so,
    to synchronize in case there are more developers wanting to increase the
    version number at the same time.
@@ -317,14 +317,14 @@ any statements) you can just drop the migration again.
 
 3. Afterwards you need to generate the deployment files for existing installations,
    this is done by running `./script/upgradedb --prepare_upgrade`.
-   After doing so, the directories +dbicdh/$ENGINE/deploy/<new version>+ and
-   +dbicdh/$ENGINE/upgrade/<prev version>-<new version>+ for PostgreSQL
+   After doing so, the directories `dbicdh/$ENGINE/deploy/<new version>` and
+   `dbicdh/$ENGINE/upgrade/<prev version>-<new version>` for PostgreSQL
    should have been created with some SQL files inside containing the statements to
    initialize the schema and to upgrade from one version
    to the next in the corresponding database engine.
 
 4. Custom migration scripts to upgrade from previous versions can be added under
-   +dbicdh/_common/upgrade+. Create a +<prev_version>-<new_version>+ directory and
+   `dbicdh/_common/upgrade`. Create a `<prev_version>-<new_version>` directory and
    put some files there with DBIx commands for the migration. For examples just
    have a look at the migrations which are already there.
    The custom migration scripts are executed in addition to the automatically
@@ -355,14 +355,14 @@ Note: This section might not be relevant anymore. At least there are currently
 none of the mentioned directories with files containing SQL statements present.
 
 Fixtures (initial data stored in tables at installation time) are stored
-in files into the +dbicdh/_common/deploy/_any/<version>+ and
-+dbicdh/_common/upgrade/<prev_version>-<next_version>+ directories.
+in files into the `dbicdh/_common/deploy/_any/<version>` and
+`dbicdh/_common/upgrade/<prev_version>-<next_version>` directories.
 
 You can create as many files as you want in each directory. These files contain
 SQL statements that will be executed when initializing or upgrading a database.
 Note that those files (and directories) have to be created manually.
 
-Executed SQL statements can be traced by setting the +DBIC_TRACE+ environment
+Executed SQL statements can be traced by setting the `DBIC_TRACE` environment
 variable.
 
 [source,sh]
@@ -372,7 +372,7 @@ export DBIC_TRACE=1
 
 == How to overwrite config files
 
-It can be necessary during development to change the config files in +etc/+.
+It can be necessary during development to change the config files in `etc/`.
 For example you have to edit etc/openqa/database.ini to use another database.
 Or to increase the log level it's useful to set the loglevel to debug in
 etc/openqa/openqa.ini.
@@ -394,14 +394,14 @@ client.conf and workers.ini.
 OpenQA comes with three authentication modules providing authentication methods:
 OpenID, iChain and Fake (see <<Installing.asciidoc#authentication,User authentication>>).
 
-All authentication modules reside in +lib/OpenQA/Auth+ directory. During
-OpenQA start, +[auth]/method+ section of +/etc/openqa/openqa.ini+ is read and according
+All authentication modules reside in `lib/OpenQA/Auth` directory. During
+OpenQA start, `[auth]/method` section of `/etc/openqa/openqa.ini` is read and according
 to its value (or default OpenID) OpenQA tries to require OpenQA::WebAPI::Auth::$method.
 If successful, module for given method is imported or the OpenQA ends with error.
 
 
-Each authentication module is expected to export +auth_login+ and +auth_logout+ functions. In case of request-response mechanism (as in
-OpenID), +auth_response+ is imported on demand.
+Each authentication module is expected to export `auth_login` and `auth_logout` functions. In case of request-response mechanism (as in
+OpenID), `auth_response` is imported on demand.
 
 Currently there is no login page because all implemented methods use either 3rd party
 page or none.
@@ -425,8 +425,8 @@ after user validation. See included modules for inspiration.
 [id="customize_base_directory"]
 
 It is possible to customize the openQA base directory (which is for instance used to store
-test results) by setting the environment variable +OPENQA_BASEDIR+. The default value
-is +/var/lib+. Be sure to clear that variable when running unit tests locally (see next
+test results) by setting the environment variable `OPENQA_BASEDIR`. The default value
+is `/var/lib`. Be sure to clear that variable when running unit tests locally (see next
 section). Take into account that the test results and assets can need a big amount of disk
 space.
 
@@ -436,12 +436,12 @@ tests are executed in the same environment as on CircleCI. This allows to reprod
 specific to that environment.
 
 === Run tests without container
-Be sure to install all required dependencies. The package +openQA-devel+ will
+Be sure to install all required dependencies. The package `openQA-devel` will
 provide them.
 
 If the package is not available the dependencies can also be found in the file
 `openQA.spec` in the openQA repository. In this case also the package
-+perl-Selenium-Remote-Driver+ is required to run UI tests. You also need to
+`perl-Selenium-Remote-Driver` is required to run UI tests. You also need to
 install chromedriver and either chrome or chromium for the UI tests.
 
 To execute the testsuite use `make test`. This will also initialize a
@@ -498,14 +498,14 @@ So by replacing VAR1 and VAR2 with those values one can trigger the different te
 Of course it is also possible to run (specific) tests directly via `prove` instead of using the Makefile targets.
 
 ==== Tips
-Commands passed to +docker run+ will be executed after the initialization script (which does database creation and so on). So if there is
+Commands passed to `docker run` will be executed after the initialization script (which does database creation and so on). So if there is
 the need to run an interactive session after it just do:
 
   docker run -it -v OPENQA_LOCAL_CODE:/opt/openqa openqa:latest bash
 
-Of course you can also use +make run-tests-within-container \; bash+ to run the tests first and then open a shell for further investigation.
+Of course you can also use `make run-tests-within-container \; bash` to run the tests first and then open a shell for further investigation.
 
-There is also the possibility to change the initialization scripts with the +--entrypoint switch+. This allows us to go into an interactive
+There is also the possibility to change the initialization scripts with the `--entrypoint switch`. This allows us to go into an interactive
 session without any initialization script run:
 
   docker run -it --entrypoint /bin/bash -v OPENQA_LOCAL_CODE:/opt/openqa registry.opensuse.org/devel/openqa/containers/openqa_dev
@@ -516,7 +516,7 @@ In case there is the need to follow what is happening in the currently running c
 
 Running UI tests in non-headless mode is also possible, eg.:
 
-  xhost +local:root
+  xhost `local:root
   docker run --rm -ti --name openqa-testsuite -v /tmp/.X11-unix:/tmp/.X11-unix:rw -e DISPLAY="$DISPLAY" -e NOT_HEADLESS=1 openqa:latest prove -v t/ui/14-dashboard.t
   xhost -local:root
 
@@ -524,12 +524,12 @@ It is also possible to use a custom os-autoinst checkout using the following arg
 
   docker run … -e CUSTOM_OS_AUTOINST=1 -v /path/to/your/os-autoinst:/opt/os-autoinst make run-tests-within-container
 
-By default, +configure+ and +make+ are still executed (so a clean checkout is expected). If your checkout is already prepared to use,
-set +CUSTOM_OS_AUTOINST_SKIP_BUILD+ to prevent this. Be aware that the build produced outside of the container might not work inside the
+By default, `configure` and `make` are still executed (so a clean checkout is expected). If your checkout is already prepared to use,
+set `CUSTOM_OS_AUTOINST_SKIP_BUILD` to prevent this. Be aware that the build produced outside of the container might not work inside the
 container if both environments provide different, incompatible library versions (eg. OpenCV).
 
 It is also important to mention that your local repositories will be copied into the container. This can take very long if those are big,
-e.g. when the openQA repo contains a lot of profiling data because you enabled +Mojolicious::Plugin::NYTProf+.
+e.g. when the openQA repo contains a lot of profiling data because you enabled `Mojolicious::Plugin::NYTProf`.
 
 In general, if starting the tests via Docker seems to hang, it is a good idea to inspect the process tree to see which command is currently
 executed.
@@ -537,14 +537,14 @@ executed.
 === Logging behavior
 
 Logs are redirected to a logfile when running tests within the CI. The output
-can therefore not be asserted using +Test::Output+. This can be worked around
-by temporarily assigning a different +Mojo::Log+ object to the application. To
+can therefore not be asserted using `Test::Output`. This can be worked around
+by temporarily assigning a different `Mojo::Log` object to the application. To
 test locally under the same condition set the environment variable
-+OPENQA_LOGFILE+.
+`OPENQA_LOGFILE`.
 
 Note that redirecting the logs to a logfile only works for tests which run
-+OpenQA::Setup::setup_log+. In other tests the log is just printed to the
-standard output. This makes use of +Test::Output+ simple but it should be
+`OpenQA::Setup::setup_log`. In other tests the log is just printed to the
+standard output. This makes use of `Test::Output` simple but it should be
 taken care that the test output is not cluttered by log messages which can be
 quite irritating.
 
@@ -637,7 +637,7 @@ normal CPAN modules and installed as such alongside openQA.
 Plugins are a good choice especially for extensions to the UI and HTTP API, but
 also for notification systems listening to various events inside the web server.
 
-If your plugin was named +OpenQA::WebAPI::Plugin::Hello+, you would install it
+If your plugin was named `OpenQA::WebAPI::Plugin::Hello`, you would install it
 in one of the include directories of the Perl used to run openQA, and then
 configure it in `openqa.ini`. The `plugins` setting in the `global` section will
 tell openQA what plugins to load.
@@ -731,8 +731,8 @@ And if you need code examples, there are some plugins
 https://github.com/os-autoinst/openQA/tree/master/lib/OpenQA/WebAPI/Plugin[included with openQA].
 
 == Checking for JavaScript problems
-One can use the tool +jshint+ to check for problems within JavaScript code. It can be installed
-easily via +npm+.
+One can use the tool `jshint` to check for problems within JavaScript code. It can be installed
+easily via `npm`.
 
 [source,sh]
 --------------------------------------------------------------------------------
@@ -741,12 +741,12 @@ node_modules/jshint/bin/jshint path/to/javascript.js
 --------------------------------------------------------------------------------
 
 == Profiling the web UI
-1. Install NYTProf, under openSUSE Tumbleweed: +zypper in perl-Devel-NYTProf perl-Mojolicious-Plugin-NYTProf+
-2. Put +profiling_enabled = 1+ in  +openqa.ini+.
+1. Install NYTProf, under openSUSE Tumbleweed: `zypper in perl-Devel-NYTProf perl-Mojolicious-Plugin-NYTProf`
+2. Put `profiling_enabled = 1+ in  `openqa.ini`.
 3. Optionally import production data like described in the official contributers documentation.
 4. Restart the web UI, browse some pages. Profiling is done in the background.
-5. Access profiling data via +/nytprof+ route.
+5. Access profiling data via `/nytprof` route.
 
 === Note
-Profiling data is extensive. Remove it if you do not need it anymore and disable the +profiling_enabled+
+Profiling data is extensive. Remove it if you do not need it anymore and disable the `profiling_enabled`
 configuration again if not needed anymore.

--- a/docs/ExternalResults.asciidoc
+++ b/docs/ExternalResults.asciidoc
@@ -22,7 +22,7 @@ be easily extended to include more formats, such as RSpec or TAP.
 The requirements to use this functionality, are quite simple:
 
 * The test harness must produce a compatible format with supported {parser-format}.
-* The test results can be uploaded via +testapi::parse_extra_log+ within an openQA tests.
+* The test results can be uploaded via `testapi::parse_extra_log` within an openQA tests.
 * The test results can also be uploaded via web {api-endpoint}.
 
 openQA will store these results in its own internal format for easier presentation,
@@ -31,12 +31,12 @@ but still will allow the original file to be downloaded.
 == Usage
 
 If a test developer wishes to use the functional interface, after finishing the
-execution of the the testing too, calling +testapi::parse_extra_log+ with the
+execution of the the testing too, calling `testapi::parse_extra_log` with the
 location to a the file generated.
 
 === openQA test distribution
 
-From within a common openQA test distribution, a developer can use +parse_extra_log+
+From within a common openQA test distribution, a developer can use `parse_extra_log`
 to upload a text file that contains a supported test output:
 
 [source,perl]
@@ -70,12 +70,12 @@ test results, test definition and test output.
 === Structured data
 
 In structured data mode, elements of the collections are objects. They can be
-of any type, even though subclassing or objects of type of +OpenQA::Parser::Result+
+of any type, even though subclassing or objects of type of `OpenQA::Parser::Result`
 are prefered.
 
 One thing to keep in mind, is that in case deeply nested objects need to be parsed
-like hash of hashes, array of hashes, they would need to subclass +OpenQA::Parser::Result+
-or +OpenQA::Parser::Results+ respectively.
+like hash of hashes, array of hashes, they would need to subclass `OpenQA::Parser::Result`
+or `OpenQA::Parser::Results` respectively.
 
 As an example, JUnit format can be parsed this way:
 

--- a/docs/GettingStarted.asciidoc
+++ b/docs/GettingStarted.asciidoc
@@ -127,7 +127,7 @@ arch:: an architecture variant of a _product_, e.g. "x86_64"
 machine:: additional variant of machine, e.g. used for "64bit", "uefi", etc.
 
 scenario:: A composition of
-+<distri>-<version>-<flavor>-<arch>-<test_suite>@<machine>+, e.g.
+`<distri>-<version>-<flavor>-<arch>-<test_suite>@<machine>`, e.g.
 "openSUSE-Tumbleweed-DVD-x86_64-gnome@64bit", nicknamed _koala_
 
 build:: Different versions of a product as tested, can be considered a
@@ -167,9 +167,9 @@ overall result from the following list.
   point.
 * *softfailed* At least one known, non-critical issue has been found. That could be
   that workaround needles are in place, a softfailure has been recorded explicitly
-  via +record_soft_failure+ (from os-autoinst) or a job failure has been ignored
+  via `record_soft_failure` (from os-autoinst) or a job failure has been ignored
   explicitly via a <<UsersGuide.asciidoc#_show_bug_or_label_icon_on_overview_if_labeled_gh550,job label>>.
-* *timeout_exceeded* The job was aborted because +MAX_JOB_TIME+ was exceeded, which is
+* *timeout_exceeded* The job was aborted because `MAX_JOB_TIME` was exceeded, which is
   by default two hours.
 * *skipped* Dependencies failed so the job was not started.
 * *obsoleted* The job was superseded by scheduling a new product.
@@ -283,8 +283,8 @@ blog post] about the subject by the openQA development team.
 === Job groups
 
 A job can belong to a job group. Those job groups are displayed on the index
-page when there are recent test results in these job groups and in the +Job
-Groups+ menu on the navigation bar. From there the job group overview pages
+page when there are recent test results in these job groups and in the `Job
+Groups` menu on the navigation bar. From there the job group overview pages
 can be accessed. Besides the test results the job group overview pages provide
 a description about the job group and allow commenting.
 
@@ -299,7 +299,7 @@ the index page.
 
 === Cleanup
 IMPORTANT: openQA automatically deletes data that it considers "old" based on
-different settings. For example job data is deleted from old jobs by the +gru+ task.
+different settings. For example job data is deleted from old jobs by the `gru` task.
 
 The following cleanup settings can be done on job-group-level:
 
@@ -327,13 +327,13 @@ the mentioned cleanup properties.
 == Using the client script
 :openqa-personal-configuration: ~/.config/openqa/client.conf
 
-Just as the worker uses an API key+secret every user of the +client script+
+Just as the worker uses an API key+secret every user of the `client script`
 must do the same. The same API key+secret as previously created can be used or
 a new one created over the webUI.
 
 The personal configuration should be stored in a file
 `{openqa-personal-configuration}` in the same format as previously described for
-the +client.conf+, i.e. sections for each machine, e.g. `localhost`.
+the `client.conf`, i.e. sections for each machine, e.g. `localhost`.
 
 [[get-testing]]
 == Testing openSUSE or Fedora
@@ -348,7 +348,7 @@ this document should help you to get started faster.
 First you need to get actual tests. You can get openSUSE tests and needles (the
 expected results) from
 https://github.com/os-autoinst/os-autoinst-distri-opensuse[GitHub]. It belongs
-into the +/var/lib/openqa/tests/opensuse+ directory. To make it easier, you can just
+into the `/var/lib/openqa/tests/opensuse` directory. To make it easier, you can just
 run
 
 [source,sh]
@@ -387,8 +387,8 @@ following command:
 
 This will load some default settings that were used at some point of time in
 openSUSE production openQA. Therefore those should work reasonably well with
-openSUSE tests and needles. This script uses +/usr/share/openqa/script/load_templates+,
-consider reading its help page (+--help+) for documentation on possible extra arguments.
+openSUSE tests and needles. This script uses `/usr/share/openqa/script/load_templates`,
+consider reading its help page (`--help`) for documentation on possible extra arguments.
 
 For Fedora, similarly, you can call:
 
@@ -398,14 +398,14 @@ For Fedora, similarly, you can call:
 --------------------------------------------------------------------------------
 
 Some Fedora tests require special hard disk images to be present in
-+/var/lib/openqa/share/factory/hdd/fixed+. The +createhdds.py+ script in the
+`/var/lib/openqa/share/factory/hdd/fixed`. The `createhdds.py` script in the
 https://pagure.io/fedora-qa/createhdds[createhdds]
 repository can be used to create these. See the documentation in that repo
 for more information.
 
 === Adding a new ISO to test
 
-To start testing a new ISO put it in +/var/lib/openqa/share/factory/iso+ and call
+To start testing a new ISO put it in `/var/lib/openqa/share/factory/iso` and call
 the following commands:
 
 [source,sh]
@@ -421,10 +421,10 @@ openqa-client isos post \
 --------------------------------------------------------------------------------
 
 If your openQA is not running on port 80 on 'localhost', you can add option
-+--host=http://otherhost:9526+ to specify a different port or host.
+`--host=http://otherhost:9526` to specify a different port or host.
 
 WARNING: Use only the ISO filename in the 'client' command. You must place the
-file in +/var/lib/openqa/share/factory/iso+. You cannot place the file elsewhere and
+file in `/var/lib/openqa/share/factory/iso`. You cannot place the file elsewhere and
 specify its path in the command. However, openQA also supports a
 remote-download feature of assets from trusted domains.
 

--- a/docs/Installing.asciidoc
+++ b/docs/Installing.asciidoc
@@ -55,7 +55,7 @@ curl -s https://raw.githubusercontent.com/os-autoinst/openQA/master/script/openq
 -------------------------------------------------------------------------------
 
 openQA-bootstrap supports to immediately clone an existing job simply by
-supplying +openqa-clone-job+ parameters directly for a quickstart:
+supplying `openqa-clone-job` parameters directly for a quickstart:
 
 [source,sh]
 ----
@@ -65,7 +65,7 @@ supplying +openqa-clone-job+ parameters directly for a quickstart:
 The above command will bootstrap an openQA installation and immediately
 afterwards start a local test job clone from a test job from a remote instance
 with optional, overridden parameters. More information about
-+openqa-clone-job+ can be found in
+`openqa-clone-job` can be found in
 <<UsersGuide.asciidoc#_cloning_existing_jobs_openqa_clone_job,Cloning existing jobs - openqa-clone-job>>.
 
 
@@ -168,7 +168,7 @@ detailed setup instructions with all the details.
 
 It is required to run openQA behind an http proxy (apache, nginx, etc..). See the
 *openqa.conf.template* config file in */etc/apache2/vhosts.d* (openSUSE) or
-+/etc/httpd/conf.d+ (Fedora). To make everything work correctly on openSUSE, you
+`/etc/httpd/conf.d` (Fedora). To make everything work correctly on openSUSE, you
 need to enable the 'headers', 'proxy', 'proxy_http', 'proxy_wstunnel' and 'rewrite'
 modules using the command 'a2enmod'. This is not necessary on Fedora.
 
@@ -183,7 +183,7 @@ a2enmod proxy_wstunnel
 a2enmod rewrite
 --------------------------------------------------------------------------------
 
-For a basic setup, you can copy *openqa.conf.template* to *openqa.conf* and modify the +ServerName+ if required
+For a basic setup, you can copy *openqa.conf.template* to *openqa.conf* and modify the `ServerName` if required
 setting. This will direct all HTTP traffic to openQA.
 
 [source,sh]
@@ -193,13 +193,13 @@ cp /etc/apache2/vhosts.d/openqa.conf.template /etc/apache2/vhosts.d/openqa.conf
 
 === TLS/SSL
 
-By default openQA expects to be run with HTTPS. The +openqa-ssl.conf.template+
+By default openQA expects to be run with HTTPS. The `openqa-ssl.conf.template`
 Apache config file is available as a base for creating the Apache config; you
-can copy it to +openqa-ssl.conf+ and uncomment any lines you like, then
+can copy it to `openqa-ssl.conf` and uncomment any lines you like, then
 ensure a key and certificate are installed to the appropriate location
 (depending on distribution and whether you uncommented the lines for key and
 cert location in the config file). On openSUSE, you should also add *SSL* to the
-*APACHE_SERVER_FLAGS* so it looks like this in +/etc/sysconfig/apache2+:
+*APACHE_SERVER_FLAGS* so it looks like this in `/etc/sysconfig/apache2`:
 
 [source,sh]
 --------------------------------------------------------------------------------
@@ -207,7 +207,7 @@ APACHE_SERVER_FLAGS="SSL"
 --------------------------------------------------------------------------------
 
 If you don't have a TLS/SSL certificate for your host you must turn HTTPS off.
-You can do that in +/etc/openqa/openqa.ini+:
+You can do that in `/etc/openqa/openqa.ini`:
 
 [source,ini]
 --------------------------------------------------------------------------------
@@ -222,10 +222,10 @@ httpsonly = 0
 Since version _4.5.1512500474.437cc1c7_ of openQA, PostgreSQL is used as the
 database.
 
-To configure access to the database in openQA, edit +/etc/openqa/database.ini+
-and change the settings in the +[production]+ section.
+To configure access to the database in openQA, edit `/etc/openqa/database.ini`
+and change the settings in the `[production]` section.
 
-The +dsn+ value format technically depends on the database type and is
+The `dsn` value format technically depends on the database type and is
 documented for PostgreSQL at
 https://metacpan.org/pod/DBD::Pg#DBI-Class-Methods[DBD::Pg]
 
@@ -256,7 +256,7 @@ according to
 === User authentication
 
 OpenQA supports three different authentication methods - OpenID (default), iChain
-and Fake. See +auth+ section in +/etc/openqa/openqa.ini+.
+and Fake. See `auth` section in `/etc/openqa/openqa.ini`.
 
 [source,ini]
 --------------------------------------------------------------------------------
@@ -271,7 +271,7 @@ will automatically get administrator rights!
 === OpenID
 
 By default openQA uses OpenID with opensuse.org as OpenID provider.
-OpenID method has its own +openid+ section in +/etc/openqa/openqa.ini+:
+OpenID method has its own `openid` section in `/etc/openqa/openqa.ini`:
 
 [source,ini]
 --------------------------------------------------------------------------------
@@ -295,7 +295,7 @@ For development purposes only! Fake authentication bypass any authentication and
 automatically allow any login requests as 'Demo user' with administrator privileges
 and without password. To ease worker testing, API key and secret is created (or updated)
 with validity of one day during login.
-You can then use following as +/etc/openqa/client.conf+:
+You can then use following as `/etc/openqa/client.conf`:
 
 [source,ini]
 --------------------------------------------------------------------------------
@@ -325,8 +325,8 @@ systemctl restart httpd
 --------------------------------------------------------------------------------
 
 The openQA web UI should be available on http://localhost/ now. To simply
-start openQA without enabling it permanently one can simply use +systemctl
-start+ instead.
+start openQA without enabling it permanently one can simply use `systemctl
+start` instead.
 
 == Run workers
 
@@ -345,13 +345,13 @@ dnf install openqa-worker
 To allow workers to access your instance, you need to log into openQA as
 operator and create a pair of API key and secret. Once you are logged in, in the
 top right corner, is the user menu, follow the link 'manage API keys'.  Click
-the 'create' button to generate +key+ and +secret+. There is also a script
+the 'create' button to generate `key` and `secret`. There is also a script
 available for creating an admin user and an API key+secret pair
-non-interactively, +/usr/share/openqa/script/create_admin+, which can be useful
+non-interactively, `/usr/share/openqa/script/create_admin`, which can be useful
 for scripted deployments of openQA. Copy and paste the key and secret into
-+/etc/openqa/client.conf+ on the machine(s) where the worker is installed. Make
+`/etc/openqa/client.conf` on the machine(s) where the worker is installed. Make
 sure to put in a section reflecting your webserver URL. In the simplest case,
-your +client.conf+ may look like this:
+your `client.conf` may look like this:
 
 [source,ini]
 --------------------------------------------------------------------------------
@@ -360,8 +360,14 @@ key = 1234567890ABCDEF
 secret = 1234567890ABCDEF
 --------------------------------------------------------------------------------
 
-To start the workers you can use the provided systemd files via +systemctl
-start openqa-worker@1+. This will start worker number one. You can start as
+To start the workers you can use the provided systemd files via:
+
+[source,sh]
+--------------------------------------------------------------------------------
+systemctl start openqa-worker@1
+--------------------------------------------------------------------------------
+
+This will start worker number one. You can start as
 many workers as you dare, you just need to supply different 'worker id' (number
 after @).
 
@@ -374,8 +380,8 @@ sudo -u _openqa-worker /usr/share/openqa/script/worker --instance X
 --------------------------------------------------------------------------------
 
 This will run a worker manually showing you debug output. If you haven't
-installed 'os-autoinst' from packages make sure to pass +--isotovideo+ option
-to point to the checkout dir where isotovideo is, not to +/usr/lib+! Otherwise
+installed 'os-autoinst' from packages make sure to pass `--isotovideo` option
+to point to the checkout dir where isotovideo is, not to `/usr/lib`! Otherwise
 it will have trouble finding its perl modules.
 
 == Where to now?
@@ -397,13 +403,13 @@ automatically to git. To do so, you need to enable git support by setting
 [global]
 scm = git
 --------------------------------------------------------------------------------
-in +/etc/openqa/openqa.ini+. Once you do so and restart the web interface, openQA will
+in `/etc/openqa/openqa.ini`. Once you do so and restart the web interface, openQA will
 automatically commit new needles to the git repository.
 
 You may want to add some description to automatic commits coming
 from the web UI.
 You can do so by setting your configuration in the repository
-(+/var/lib/os-autoinst/needles/.git/config+) to some reasonable defaults such as:
+(`/var/lib/os-autoinst/needles/.git/config`) to some reasonable defaults such as:
 
 [source,ini]
 --------------------------------------------------------------------------------
@@ -443,7 +449,7 @@ example bugzilla), this job is automatically labeled as linked and treated as
 important.
 
 List of recognized referers is space separated list configured in
-+/etc/openqa/openqa.ini+:
+`/etc/openqa/openqa.ini`:
 
 [source,ini]
 --------------------------------------------------------------------------------
@@ -455,7 +461,7 @@ recognized_referers = bugzilla.suse.com bugzilla.opensuse.org
 
 Default behavior for all workers is to use the 'Qemu' backend and connect to
 'http://localhost'. If you want to change some of those options, you can do so
-in +/etc/openqa/workers.ini+. For example to point the workers to the FQDN of
+in `/etc/openqa/workers.ini`. For example to point the workers to the FQDN of
 your host (needed if test cases need to access files of the host) use the
 following setting:
 
@@ -473,13 +479,13 @@ of openQA up and running and all that is left is to set up some tests.
 
 There are some additional requirements to get remote worker running. First is to
 ensure shared storage between openQA WebUI and workers.
-Directory +/var/lib/openqa/share+ contains all required data and should be
+Directory `/var/lib/openqa/share` contains all required data and should be
 shared with read-write access across all nodes present in openQA cluster.
 This step is intentionally left on system administrator to choose proper shared
 storage for her specific needs.
 
 Example of NFS configuration:
-NFS server is where openQA WebUI is running. Content of +/etc/exports+
+NFS server is where openQA WebUI is running. Content of `/etc/exports`
 [source,sh]
 --------------------------------------------------------------------------------
 /var/lib/openqa/share *(fsid=0,rw,no_root_squash,sync,no_subtree_check)
@@ -502,8 +508,8 @@ for more info about the server and the message topic format.
 There you will find instructions how to configure the AMQP server as well.
 
 To let openQA send messages to an AMQP message bus,
-first make sure that the +perl-Mojo-RabbitMQ-Client+ RPM is installed.
-Then you will need to configure amqp in +/etc/openqa/openqa.ini+:
+first make sure that the `perl-Mojo-RabbitMQ-Client` RPM is installed.
+Then you will need to configure amqp in `/etc/openqa/openqa.ini`:
 
 [source,ini]
 --------------------------------------------------------------------------------
@@ -517,7 +523,7 @@ exchange = pubsub
 topic_prefix = suse
 --------------------------------------------------------------------------------
 
-For a TLS connection use +amqps://+ and port +5671+.
+For a TLS connection use `amqps://` and port `5671`.
 
 
 === Configuring worker to use more than one openQA server
@@ -527,10 +533,10 @@ can be configured to register and accept jobs from all of them.
 
 Requirements:
 
-* +/etc/openqa/client.conf+ must contain API keys and secrets to all instances
+* `/etc/openqa/client.conf` must contain API keys and secrets to all instances
 * Shared storage from all instances must be properly mounted
 
-In the +/etc/openqa/workers.ini+ enter space-separated instance hosts and optionally
+In the `/etc/openqa/workers.ini` enter space-separated instance hosts and optionally
 configure where the shared storage is mounted. Example:
 
 [source,ini]
@@ -545,13 +551,13 @@ SHARE_DIRECTORY = /var/lib/openqa/opensuse
 SHARE_DIRECTORY = /var/lib/openqa/fedora
 --------------------------------------------------------------------------------
 
-Configuring +SHARE_DIRECTORY+ is not a hard requirement. Worker will try following
+Configuring `SHARE_DIRECTORY` is not a hard requirement. Worker will try following
 directories prior registering with openQA instance:
 
-1. +SHARE_DIRECTORY+
-2. +/var/lib/openqa/$instance_host+
-3. +/var/lib/openqa/share+
-4. +/var/lib/openqa+
+1. `SHARE_DIRECTORY`
+2. `/var/lib/openqa/$instance_host`
+3. `/var/lib/openqa/share`
+4. `/var/lib/openqa`
 5. fail if none of above is available
 
 Once worker registers to openQA instance it checks for available job and starts
@@ -564,7 +570,7 @@ remote instances.
 
 If your network is slow or you experience long time to load needles you might
 want to consider to enable caching in your remote workers. To enable caching,
-+/var/lib/openqa/cache+ must exist, and right permissions given to the
+`/var/lib/openqa/cache` must exist, and right permissions given to the
 '_openqa-worker' user to read everything under this path. If you install
 openQA through the repositories, said directory will be created for you.
 
@@ -580,7 +586,7 @@ Enable and start the Cache Worker:
 systemctl enable --now openqa-worker-cacheservice-minion
 --------------------------------------------------------------------------------
 
-In the +/etc/openqa/workers.ini+
+In the `/etc/openqa/workers.ini`
 
 [source,ini]
 --------------------------------------------------------------------------------
@@ -625,7 +631,7 @@ systemctl enable --now rsyncd
 --------------------------------------------------------------------------------
 
 This will allow the workers to download the assets from the webUI and use them
-locally. If +TESTPOOLSERVER+ is set tests and needles will also be cached by the
+locally. If `TESTPOOLSERVER` is set tests and needles will also be cached by the
 worker.
 
 == Auditing - tracking openQA changes
@@ -635,16 +641,16 @@ Auditing plugin enables openQA administrators to maintain overview about what is
 Plugin records what event was triggered by whom, when and what the request looked like. Actions done by openQA
 workers are tracked under user whose API keys are workers using.
 
-Audit log is directly accessible from +Admin menu+.
+Audit log is directly accessible from `Admin menu`.
 
-Auditing, by default enabled, can be disabled by global configuration option in +/etc/openqa/openqa.ini+:
+Auditing, by default enabled, can be disabled by global configuration option in `/etc/openqa/openqa.ini`:
 [source,ini]
 --------------------------------------------------------------------------------
 [global]
 audit_enabled = 0
 --------------------------------------------------------------------------------
 
-The +audit+ section of +/etc/openqa/openqa.ini+ allows to exclude some events from logging using
+The `audit` section of `/etc/openqa/openqa.ini` allows to exclude some events from logging using
 a space separated blacklist:
 [source,ini]
 --------------------------------------------------------------------------------
@@ -652,7 +658,7 @@ a space separated blacklist:
 blacklist = job_grab job_done
 --------------------------------------------------------------------------------
 
-The +audit/storage_duration+ section of +/etc/openqa/openqa.ini+ allows to set the retention policy for
+The `audit/storage_duration` section of `/etc/openqa/openqa.ini` allows to set the retention policy for
 different audit event types:
 [source,ini]
 --------------------------------------------------------------------------------
@@ -668,13 +674,13 @@ needle = 30
 other = 15
 --------------------------------------------------------------------------------
 
-In this example events of the type +startup+ would be cleaned up after 10 days, events related to
+In this example events of the type `startup` would be cleaned up after 10 days, events related to
 job groups after 365 days and so on. Events which do not fall into one of these categories would be
 cleaned after 15 days. By default, cleanup is disabled.
 
-Use +systemctl enable --now openqa-enqueue-audit-event-cleanup.timer+ to schedule the cleanup
+Use `systemctl enable --now openqa-enqueue-audit-event-cleanup.timer` to schedule the cleanup
 automatically every day. It is also possible to trigger the cleanup manually by invoking
-+/usr/share/openqa/script/openqa minion job -e limit_audit_events+.
+`/usr/share/openqa/script/openqa minion job -e limit_audit_events`.
 
 === List of events tracked by the auditing plugin
 
@@ -694,104 +700,104 @@ automatically every day. It is also possible to trigger the cleanup manually by 
 * Needles:
 ** needle_delete needle_modify
 
-Some of these events are very common and may clutter audit database. For this reason +job_grab+ and +job_done+
+Some of these events are very common and may clutter audit database. For this reason `job_grab` and `job_done`
 events are blacklisted by default.
 
 [NOTE]
-Upgrading openQA does not automatically update +/etc/openqa/openqa.ini+. Review your configuration after upgrade.
+Upgrading openQA does not automatically update `/etc/openqa/openqa.ini`. Review your configuration after upgrade.
 
 == Filesystem layout
 [id="filesystem"]
 
 Tests, needles, assets, results and working directories (a.k.a. "pool directories") are located in certain
-subdirectories within +/var/lib/openqa+. This directory is configurable (see
+subdirectories within `/var/lib/openqa`. This directory is configurable (see
 <<Contributing.asciidoc#customize_base_directory,Customize base directory>>). Here we assume the default is in place.
 
-Note that the sub directories within +/var/lib/openqa+ must be accessible by the user that runs the openQA web UI
+Note that the sub directories within `/var/lib/openqa` must be accessible by the user that runs the openQA web UI
 (by default 'geekotest') or by the user that runs the worker/isotovideo (by default '_openqa-worker').
 
-These are the most important sub directories within +/var/lib/openqa+:
+These are the most important sub directories within `/var/lib/openqa`:
 
-* +db+ contains the web UI's database lockfile
-* +images+ is where the web UI stores test screenshots and thumbnails
-* +testresults+ is where the web UI stores test logs and test-generated assets
-* +webui+ is where the web UI stores miscellaneous files
-* +pool+ contains working directories of the workers/isotovideo
-* +share+ contains directories shared between the web UI and (remote) workers, can be owned by root
-* +share/factory+ contains test assets and temp directory, can be owned by root but sysadmin must create subdirs
-* +share/factory/iso+ and +share/factory/iso/fixed+ contain ISOs for tests
-* +share/factory/hdd+ and +share/factory/hdd/fixed+ contain hard disk images for tests
-* +share/factory/repo+ and +share/factory/repo/fixed+ contain repositories for tests
-* +share/factory/other+ and +share/factory/other/fixed+ contain miscellaneous test assets (e.g. kernels and initrds)
-* +share/factory/tmp+ is used as a temporary directory (openQA will create it if it owns +share/factory+)
-* +share/tests+ contains the tests themselves
+* `db` contains the web UI's database lockfile
+* `images` is where the web UI stores test screenshots and thumbnails
+* `testresults` is where the web UI stores test logs and test-generated assets
+* `webui` is where the web UI stores miscellaneous files
+* `pool` contains working directories of the workers/isotovideo
+* `share` contains directories shared between the web UI and (remote) workers, can be owned by root
+* `share/factory` contains test assets and temp directory, can be owned by root but sysadmin must create subdirs
+* `share/factory/iso` and `share/factory/iso/fixed` contain ISOs for tests
+* `share/factory/hdd` and `share/factory/hdd/fixed` contain hard disk images for tests
+* `share/factory/repo` and `share/factory/repo/fixed` contain repositories for tests
+* `share/factory/other` and `share/factory/other/fixed` contain miscellaneous test assets (e.g. kernels and initrds)
+* `share/factory/tmp` is used as a temporary directory (openQA will create it if it owns `share/factory`)
+* `share/tests` contains the tests themselves
 
-Each of the asset directories (+factory/iso+, +factory/hdd+, +factory/repo+ and
-+factory/other+) may contain a +fixed/+ subdirectory, and assets of the same
-type may be placed in that directory. Placing an asset in the +fixed/+
+Each of the asset directories (`factory/iso`, `factory/hdd`, `factory/repo` and
+`factory/other`) may contain a `fixed/` subdirectory, and assets of the same
+type may be placed in that directory. Placing an asset in the `fixed/`
 subdirectory indicates that it should not be deleted to save space: the GRU
 task which removes old assets when the size of all assets for a given job
-group is above a specified size will ignore assets in the +fixed/+
+group is above a specified size will ignore assets in the `fixed/`
 subdirectories.
 
 It also contains several symlinks which are necessary due to various things
 moving around over the course of openQA's development. All the symlinks
 can of course be owned by root:
 
-* +script+ (symlink to +/usr/share/openqa/script/+)
-* +tests+ (symlink to +share/tests+)
-* +factory+ (symlink to +share/factory+)
+* `script` (symlink to `/usr/share/openqa/script/`)
+* `tests` (symlink to `share/tests`)
+* `factory` (symlink to `share/factory`)
 
 It is always best to use the canonical locations, not the compatibility
-symlinks - so run scripts from +/usr/share/openqa/script+, not
-+/var/lib/openqa/script+.
+symlinks - so run scripts from `/usr/share/openqa/script`, not
+`/var/lib/openqa/script`.
 
 You only need the asset directories for the asset types you will actually use,
 e.g. if none of your tests refer to openQA-stored repositories, you will need
-no +factory/repo+ directory. The distribution packages may not create all
+no `factory/repo` directory. The distribution packages may not create all
 asset directories, so make sure the ones you need are created if necessary.
 Packages will likewise usually not contain any tests; you must create your
 own tests, or use existing tests for some distribution or other piece of
 software.
 
-The worker needs to own +/var/lib/openqa/pool/$INSTANCE+, e.g.
+The worker needs to own `/var/lib/openqa/pool/$INSTANCE`, e.g.
 
-* +/var/lib/openqa/pool/1+
-* +/var/lib/openqa/pool/2+
+* `/var/lib/openqa/pool/1`
+* `/var/lib/openqa/pool/2`
 * ... - add more if you have more worker instances
 
-You can also give the whole pool directory to the +_openqa-worker+ user and let
+You can also give the whole pool directory to the `_openqa-worker` user and let
 the workers create their own instance directories.
 
 === Terms and variables for certain directories used by openQA and isotovideo
 * the "base directory"
-    - by default +/var/lib+
-    - configurable via environment variable +OPENQA_BASEDIR+
-    - referred as +$basedir+ within openQA
+    - by default `/var/lib`
+    - configurable via environment variable `OPENQA_BASEDIR`
+    - referred as `$basedir` within openQA
 * the "project directory"
-    - defined as +$basedir/openqa+, by default +/var/lib/openqa+
-    - referred as +$prjdir+ within openQA
+    - defined as `$basedir/openqa`, by default `/var/lib/openqa`
+    - referred as `$prjdir` within openQA
 * the "share directory": contains directories shared between web UI and (remote) workers
-    - defined as +$prjdir/share+, by default +/var/lib/openqa/share+
-    - referred as +$sharedir+ within openQA
+    - defined as `$prjdir/share`, by default `/var/lib/openqa/share`
+    - referred as `$sharedir` within openQA
 * the "test case directory": contains a test distribution
-    - by default +$sharedir/tests/$distri+ or +$sharedir/tests/$distri-$version+
-    - configurable via the test variable +CASEDIR+ (see backend variables documentation)
-    - this default is provided by openQA; when starting isotovideo manually the +CASEDIR+ variable *must* be
+    - by default `$sharedir/tests/$distri` or `$sharedir/tests/$distri-$version`
+    - configurable via the test variable `CASEDIR` (see backend variables documentation)
+    - this default is provided by openQA; when starting isotovideo manually the `CASEDIR` variable *must* be
       initialized by hand
-    - might contain the sub directory +lib+ for placing Perl modules used by the tests
-* the "product directory": contains the test schedule (+main.pm+) for a certain product within a test distribution
+    - might contain the sub directory `lib` for placing Perl modules used by the tests
+* the "product directory": contains the test schedule (`main.pm`) for a certain product within a test distribution
     - by default identical to the "test case directory"
-    - usually a directory +products/$distri+ within the "test case directory"
-    - configurable via the test variable +PRODUCTDIR+ (see backend variables documentation)
+    - usually a directory `products/$distri` within the "test case directory"
+    - configurable via the test variable `PRODUCTDIR` (see backend variables documentation)
 * the "needles directory": contains reference images for a certain product within a test distribution
-    - by default +$PRODUCTDIR/needles+
-    - configurable via the test variable +NEEDLES_DIR+ (see backend variables documentation)
+    - by default `$PRODUCTDIR/needles`
+    - configurable via the test variable `NEEDLES_DIR` (see backend variables documentation)
 
 ==== Further notes
 * Setting the test variables has only an influence on os-autoinst. The web UI on the other hand always relies
   on the directory structure described above. For the exact details how these paths are computed by the web UI
-  have a look at +lib/OpenQA/Utils.pm+.
+  have a look at `lib/OpenQA/Utils.pm`.
 * When enabling the worker cache parts of the usual "share directory" are located in the specified cache
   directory on the worker host.
 
@@ -801,14 +807,14 @@ the workers create their own instance directories.
 === Tests fail quickly
 
 
-Check the log files in +/var/lib/openqa/testresults+
+Check the log files in `/var/lib/openqa/testresults`
 
 === KVM doesn't work
 
 * make sure you have a machine with kvm support
-* make sure +kvm_intel+ or +kvm_amd+ modules are loaded
+* make sure `kvm_intel` or `kvm_amd` modules are loaded
 * make sure you do have virtualization enabled in BIOS
-* make sure the '_openqa-worker' user can access +/dev/kvm+
+* make sure the '_openqa-worker' user can access `/dev/kvm`
 * make sure you are not already running other hypervisors such as VirtualBox
 * when running inside a vm make sure nested virtualization is enabled (pass nested=1 to your kvm module)
 

--- a/docs/Networking.asciidoc
+++ b/docs/Networking.asciidoc
@@ -8,7 +8,7 @@
 IMPORTANT: This overview is valid only when using the QEMU backend!
 
 The networking type used is controlled by the `NICTYPE` variable. If unset or
-empty `NICTYPE` defaults to +user+, i.e. QEMU user networking which requires
+empty `NICTYPE` defaults to `user`, i.e. QEMU user networking which requires
 no further configuration.
 
 For more advanced setups or tests that require multiple jobs to be in the same
@@ -20,19 +20,19 @@ modes can be used.
 
 With QEMU {qemu-user-networking} each jobs gets its own isolated network with
 TCP and UDP routed to the outside. DHCP is provided by QEMU. The MAC address of
-the machine can be controlled with the +NICMAC+ variable. If not set, it is
-+52:54:00:12:34:56+.
+the machine can be controlled with the `NICMAC` variable. If not set, it is
+`52:54:00:12:34:56`.
 
 === TAP Based Network
 
 os-autoinst can connect QEMU to TAP devices of the host system to
-leverage advanced network setups provided by the host by setting +NICTYPE=tap+.
+leverage advanced network setups provided by the host by setting `NICTYPE=tap`.
 
-The TAP device to use can be configured with the +TAPDEV+ variable. If not
+The TAP device to use can be configured with the `TAPDEV` variable. If not
 defined, it is automatically set to "tap" + ($worker_instance - 1), i.e.
 worker1 uses tap0, worker 2 uses tap1 and so on.
 
-For multiple networks per job (see +NETWORKS+ variable), the following numbering
+For multiple networks per job (see `NETWORKS` variable), the following numbering
 scheme is used:
 
 [source,sh]
@@ -43,8 +43,8 @@ worker3: tap2 tap66 tap130 ...
 ...
 ----
 
-The MAC address of each virtual NIC is controlled by the +NICMAC+ variable or
-automatically computed from +$worker_id+ if not set.
+The MAC address of each virtual NIC is controlled by the `NICMAC` variable or
+automatically computed from `$worker_id` if not set.
 
 In TAP mode the system administrator is expected to configure the network,
 required internet access, etc. on the host manually.
@@ -63,9 +63,9 @@ reconfigure the switch as needed by the job.
 To start with a basic configuration like QEMU user mode networking,
 create a machine with the following settings:
 
-- +VDE_SOCKETDIR=/run/openqa+
-- +NICTYPE=vde+
-- +NICVLAN=0+
+- `VDE_SOCKETDIR=/run/openqa`
+- `NICTYPE=vde`
+- `NICVLAN=0`
 
 Start the switch and user mode networking:
 
@@ -109,8 +109,8 @@ systemctl enable --now openvswitch
 *  Install and configure _os-autoinst-openvswitch.service_:
 
 NOTE: _os-autoinst-openvswitch.service_ is a support service that sets the
-vlan number of Open vSwitch ports based on +NICVLAN+ variable - this separates
-the groups of tests from each other. The +NICVLAN+ variable is dynamically
+vlan number of Open vSwitch ports based on `NICVLAN` variable - this separates
+the groups of tests from each other. The `NICVLAN` variable is dynamically
 assigned by the OpenQA scheduler. Install, start and enable the service:
 
 [source,sh]
@@ -363,7 +363,7 @@ NOTE: It is also possible to switch the network configuration using YaST.
 Boot sequence with wicked (version 0.6.23 and newer):
 
 1. openvswitch (as above)
-2. wicked - creates the bridge +br1+ and tap devices, adds tap devices to the bridge,
+2. wicked - creates the bridge `br1` and tap devices, adds tap devices to the bridge,
 3. SuSEfirewall
 4. os-autoinst-openvswitch - installs openflow rules, handles vlan assignment
 
@@ -429,7 +429,7 @@ http://openvswitch.org/support/config-cookbooks/port-tunneling/[documentation]
 for details.
 
 
-Create a gre_tunnel_preup script (change the +remote_ip+ value correspondingly
+Create a gre_tunnel_preup script (change the `remote_ip` value correspondingly
 on both hosts):
 
 [source,sh]

--- a/docs/Pitfalls.asciidoc
+++ b/docs/Pitfalls.asciidoc
@@ -19,9 +19,9 @@
 
 == 403 messages when using scripts
 
-- If you come across messages displaying +ERROR: 403 - Forbidden+, make
+- If you come across messages displaying `ERROR: 403 - Forbidden`, make
   sure that the correct API key is present in client.conf file.
-- If you are using a hostname other than +localhost+, pass *--host foo* to the script.
+- If you are using a hostname other than `localhost`, pass *--host foo* to the script.
 - If you are using fake authentication method, and the message says also "api key expired"
   you can simply logout and log in again in the webUI and the expiration will be automatically
   updated
@@ -31,7 +31,7 @@
 There are few things to take into account when running a development version and
 a packaged version of openqa:
 
-If the setup for the development scenario involves sharing +/var/lib/openqa+,
+If the setup for the development scenario involves sharing `/var/lib/openqa`,
 it would be wise to have a shared group _openqa_, that will have write and execute
 permissions over said directory, so that _geekotest_ user and the normal development
 user can share the environment without problems.
@@ -43,15 +43,15 @@ and `chgrp -R openqa /var/lib/openqa` can not fix.
 == Performance impact
 
 openQA workers can cause high I/O load, especially when creating VM snapshots.
-The impact therefore gets more severe when +MAKETESTSNAPSHOTS+ is enabled.
+The impact therefore gets more severe when `MAKETESTSNAPSHOTS` is enabled.
 should not impact the stability of openQA jobs but can increase job execution
 time. If you run jobs on a machine where responsiveness of other services
 matter, for example your desktop machine, consider patching the
 IOSchedulingPriority of a workers service file as described in the
 https://www.freedesktop.org/software/systemd/man/systemd.exec.html#IOSchedulingPriority=[systemd
-documentation], for example set +IOSchedulingPriority=7+ for the lowest
+documentation], for example set `IOSchedulingPriority=7` for the lowest
 priority. If not available then you can try to execute the worker processes
-with +ionice+ to reduce the risk of your system becoming significantly
+with `ionice` to reduce the risk of your system becoming significantly
 impacted by snapshot creation. Loading VM snapshots can also have an impact on
 SUT behavior as the execution of the first step after loading a snapshot might
 be delayed. This can lead to problems if the executed tests do not foresee an
@@ -88,25 +88,25 @@ This is basically a checklist to go through in case the developer mode is broken
   machine hosting the web UI and on the worker.
 . Check whether the web browser can reach the livehandler daemon. Go to a running test and open
   the live view. Then open the JavaScript console of the web browser. If it contains messages
-  like +Received message via ws proxy: ...+ the livehandler daemon can be reached. Otherwise,
+  like `Received message via ws proxy: ...` the livehandler daemon can be reached. Otherwise,
   try the following sub-steps:
   .. The installation guide has been updated to cover the developer mode. In case you installed
      your instance before the developer mode has been introduced, make sure that the Apache module
-     +rewrite+ is enabled (via +a2enmod rewrite+). Also be sure the vhost configuration looks
+     `rewrite` is enabled (via `a2enmod rewrite`). Also be sure the vhost configuration looks
      like the one found in the openQA Git repository (especially the part for the reverse proxies).
-  .. Check whether +openqa-livehandler.service+ is running. It is supposed to be run on
+  .. Check whether `openqa-livehandler.service` is running. It is supposed to be run on
      the same machine as the web UI and should actually be started automatically as a dependency of
-     +openqa-webui.service+.
+     `openqa-webui.service`.
 . Check whether the livehandler can reach the os-autoinst command server. Go to a running test
   and open the live view. Then open the JavaScript console of the web browser. If it contains messages
-  like +Received message via ws proxy: {...,"type":"info","what":"cmdsrvmsg"} + the os-autoinst command
+  like `Received message via ws proxy: {...,"type":"info","what":"cmdsrvmsg"}` the os-autoinst command
   server can be reached. Otherwise there should be at least a message like
-  +Received message via ws proxy: {"what":"connecting to os-autoinst command server at ws:\/\/hostname:20053\/xhB84lUuPlMfhDEF\/ws",...}+
+  `Received message via ws proxy: {"what":"connecting to os-autoinst command server at ws:\/\/hostname:20053\/xhB84lUuPlMfhDEF\/ws",...}`
   which contains the URL the livehandler is attempting to query. In this case
   try the following sub-steps:
-  .. If the hostname is wrong, add +WORKER_HOSTNAME = correcthostname+ to +workers.ini+. The worker
-     should then tell the web UI that it is reachable via +correcthostname+ resulting in a correct URL
+  .. If the hostname is wrong, add `WORKER_HOSTNAME = correcthostname` to `workers.ini`. The worker
+     should then tell the web UI that it is reachable via `correcthostname` resulting in a correct URL
      for the os-autoinst command server.
   .. It might also be the case that the firewall is blocking the HTTP/websocket connection on the required
-     port. The required port is +QEMUPORT+ plus 1.
-     By default, +QEMUPORT+ is +$worker_instance_number \* 10 \+ 20002+.
+     port. The required port is `QEMUPORT` plus 1.
+     By default, `QEMUPORT` is `$worker_instance_number \* 10 \` 20002`.

--- a/docs/UsersGuide.asciidoc
+++ b/docs/UsersGuide.asciidoc
@@ -50,15 +50,15 @@ test code run by the 'job', along with variables specified as part of the job
 creation request. Certain variables also influence openQA's and/or
 os-autoinst's own behavior in terms of how it configures the environment for
 the job. Variables that influence os-autoinst's behavior are documented in the
-file +doc/backend_vars.asciidoc+ in the os-autoinst repository.
+file `doc/backend_vars.asciidoc` in the os-autoinst repository.
 
 In openQA we can parameterize a test to describe for what product it will run
 and for what kind of machines it will be executed. For example, a test suite
-+kde+ can be run for any product that has the KDE software stack installed,
-like +openSUSE-DVD-x86_64+ and +openSUSE-NET-i586+, and can be tested in
-different x86-64 and i586 machines like +64bit+, +64bit_USBBoot+, +32bit+. In
+`kde` can be run for any product that has the KDE software stack installed,
+like `openSUSE-DVD-x86_64` and `openSUSE-NET-i586`, and can be tested in
+different x86-64 and i586 machines like `64bit`, `64bit_USBBoot`, `32bit`. In
 this example we could have the following test scenarios considering that the
-"`x86_64`" flavor is not compatible with the +32bit+ machine:
+"`x86_64`" flavor is not compatible with the `32bit` machine:
 
 * openSUSE-DVD-x86_64-kde-64bit
 * openSUSE-DVD-x86_64-kde-64bit_USBBoot
@@ -67,7 +67,7 @@ this example we could have the following test scenarios considering that the
 * openSUSE-NET-i586-kde-32bit
 
 For every test scenario we need to configure a different instance of the test
-backend, for example +os-autoinst+, with a different set of parameters.
+backend, for example `os-autoinst`, with a different set of parameters.
 
 
 === Machines
@@ -81,16 +81,16 @@ worker' connected that can fulfill those specifications.
 configuration.
 
 * *Backend.* What backend should be used for this machine. Recommended value is
-+qemu+ as it is the most tested one, but other options (such as +kvm2usb+ or +vbox+)
+`qemu` as it is the most tested one, but other options (such as `kvm2usb` or `vbox`)
 are also possible.
 
 * *Variables* Most machine variables influence os-autoinst's behavior in terms
 of how the test machine is set up. A few important examples:
-** +QEMUCPU+ can be 'qemu32' or 'qemu64' and specifies the architecture of the
+** `QEMUCPU` can be 'qemu32' or 'qemu64' and specifies the architecture of the
    virtual CPU.
-** +QEMUCPUS+ is an integer that specifies the number of cores you wish for.
-** +LAPTOP+ if set to 1, QEMU will create a laptop profile.
-** +USBBOOT+ when set to 1, the image will be loaded through an
+** `QEMUCPUS` is an integer that specifies the number of cores you wish for.
+** `LAPTOP` if set to 1, QEMU will create a laptop profile.
+** `USBBOOT` when set to 1, the image will be loaded through an
    emulated USB stick.
 
 
@@ -102,16 +102,16 @@ define or characterize this product in os-autoinst.
 
 Some example variables used by openSUSE are:
 
-* +ISO_MAXSIZE+ contains the maximum size of the product. There is a
+* `ISO_MAXSIZE` contains the maximum size of the product. There is a
   test that checks that the current size of the product is less or
   equal than this variable.
-* +DVD+ if it is set to 1, this indicates that the medium is a DVD.
-* +LIVECD+ if it is set to 1, this indicates that the medium is a live
+* `DVD` if it is set to 1, this indicates that the medium is a DVD.
+* `LIVECD` if it is set to 1, this indicates that the medium is a live
   image (can be a CD or USB)
-* +GNOME+ this variable, if it is set to 1, indicates that it is a GNOME
+* `GNOME` this variable, if it is set to 1, indicates that it is a GNOME
   only distribution.
-* +PROMO+ marks the promotional product.
-* +RESCUECD+ is set to 1 for rescue CD images.
+* `PROMO` marks the promotional product.
+* `RESCUECD` is set to 1 for rescue CD images.
 
 
 === Test Suites
@@ -123,40 +123,40 @@ behaviour according to the settings.
 
 Some sample variables used by openSUSE are:
 
-* +BTRFS+ if set, the file system will be BtrFS.
-* +DESKTOP+ possible values are 'kde' 'gnome' 'lxde' 'xfce' or
+* `BTRFS` if set, the file system will be BtrFS.
+* `DESKTOP` possible values are 'kde' 'gnome' 'lxde' 'xfce' or
   'textmode'. Used to indicate the desktop selected by the user during
   the test.
-* +DOCRUN+ used for documentation tests.
-* +DUALBOOT+ dual boot testing, needs HDD_1 and HDDVERSION.
-* +ENCRYPT+ encrypt the home directory via YaST.
-* +HDDVERSION+ used together with HDD_1 to set the operating system
+* `DOCRUN` used for documentation tests.
+* `DUALBOOT` dual boot testing, needs HDD_1 and HDDVERSION.
+* `ENCRYPT` encrypt the home directory via YaST.
+* `HDDVERSION` used together with HDD_1 to set the operating system
   previously installed on the hard disk.
-* +INSTALLONLY+ only basic installation.
-* +INSTLANG+ installation language. Actually used only in documentation
+* `INSTALLONLY` only basic installation.
+* `INSTLANG` installation language. Actually used only in documentation
   tests.
-* +LIVETEST+ the test is on a live medium, do not install the distribution.
-* +LVM+ select LVM volume manager.
-* +NICEVIDEO+ used for rendering a result video for use in show rooms,
+* `LIVETEST` the test is on a live medium, do not install the distribution.
+* `LVM` select LVM volume manager.
+* `NICEVIDEO` used for rendering a result video for use in show rooms,
   skipping ugly and boring tests.
-* +NOAUTOLOGIN+ unmark autologin in YaST
-* +NUMDISKS+ total number of disks in QEMU.
-* +REBOOTAFTERINSTALL+ if set to 1, will reboot after the installation.
-* +SCREENSHOTINTERVAL+ used with NICEVIDEO to improve the video quality.
-* +SPLITUSR+ a YaST configuration option.
-* +TOGGLEHOME+ a YaST configuration option.
-* +UPGRADE+ upgrade testing, need HDD_1 and HDDVERSION.
-* +VIDEOMODE+ if the value is 'text', the installation will be done in
+* `NOAUTOLOGIN` unmark autologin in YaST
+* `NUMDISKS` total number of disks in QEMU.
+* `REBOOTAFTERINSTALL` if set to 1, will reboot after the installation.
+* `SCREENSHOTINTERVAL` used with NICEVIDEO to improve the video quality.
+* `SPLITUSR` a YaST configuration option.
+* `TOGGLEHOME` a YaST configuration option.
+* `UPGRADE` upgrade testing, need HDD_1 and HDDVERSION.
+* `VIDEOMODE` if the value is 'text', the installation will be done in
   text mode.
 
 Some of the variables usually set in test suites that influence openQA
 and/or os-autoinst's own behavior are:
 
-* +HDDMODEL+ variable to set the HDD hardware model
-* +HDDSIZEGB+ hard disk size in GB. Used together with BtrFS variable
-* +HDD_1+ path for the pre-created hard disk
-* +RAIDLEVEL+ RAID configuration variable
-* +QEMUVGA+ parameter to declare the video hardware configuration in QEMU
+* `HDDMODEL` variable to set the HDD hardware model
+* `HDDSIZEGB` hard disk size in GB. Used together with BtrFS variable
+* `HDD_1` path for the pre-created hard disk
+* `RAIDLEVEL` RAID configuration variable
+* `QEMUVGA` parameter to declare the video hardware configuration in QEMU
 
 
 === Job Groups
@@ -195,7 +195,7 @@ by different means:
 === Variable expansion
 
 Any variable defined in Test Suite, Machine, Product or Job Template table can
-refer to another variable using this syntax: +%NAME%+. When the test job is created,
+refer to another variable using this syntax: `%NAME%`. When the test job is created,
 the string will be substituted with the value of the specified variable at that time.
 
 For example this variable defined for Test Suite:
@@ -231,13 +231,13 @@ That is, variable values set as part of the API request that triggers the jobs w
 If you need to override this precedence - for example, you want the value set in
 one particular test suite to take precedence over a setting of the same value from
 the API request - you can add a leading + to the variable name. For instance, if
-you set ++VARIABLE = foo+ in a test suite, and passed +VARIABLE=bar+ in the API
+you set `+VARIABLE = foo` in a test suite, and passed `VARIABLE=bar` in the API
 request, the test suite setting would 'win' and the value would be foo.
 
 If the same variable is set with a + prefix in multiple places, the same precedence
 order described above will apply to those settings.
 
-Note that the +WORKER_CLASS+ variable is not overridden in the way described above.
+Note that the `WORKER_CLASS` variable is not overridden in the way described above.
 Instead multiple occurrences are combined.
 
 
@@ -324,7 +324,7 @@ Related issue: https://progress.opensuse.org/issues/10212[#10212]
 'Hint:' You can also write (or copy-paste) full links to bugs and issues. The links are automatically changed to the shortlinks (e.g. `https://progress.opensuse.org/issues/11110` turns into https://progress.opensuse.org/issues/11110[poo#11110]). Related issue: https://progress.opensuse.org/issues/11110[[line-through]*poo#11110*]
 
 Also github pull requests and issues can be linked using the generic format
-+`<marker>[#<project/repo>]#<id>`+, e.g. https://github.com/os-autoinst/openQA/issues/1234[gh#os-autoinst/openQA#1234], see https://github.com/os-autoinst/openQA/pull/973[gh#973]
+``<marker>[#<project/repo>]#<id>``, e.g. https://github.com/os-autoinst/openQA/issues/1234[gh#os-autoinst/openQA#1234], see https://github.com/os-autoinst/openQA/pull/973[gh#973]
 
 All issue references are stored within the internal database of openQA. The status can be updated using the `/bugs` API route for example using external tools.
 
@@ -525,7 +525,7 @@ or admin.
 
 The developer mode allows to:
 
-* Create or update needles from +assert_screen+ mismatches ("re-needling")
+* Create or update needles from `assert_screen` mismatches ("re-needling")
 * Pause the test execution (at a certain module) for manual investigation of the SUT
 
 It can be accessed via the "Live View" tab of a running test. Only registered
@@ -538,10 +538,10 @@ In case the developer mode in not working on your instance, try to follow the
 
 ==== Workflow for creating or updating needles ====
 
-1. In case a new needles should be created, add the corresponding +assert_screen+ calls
+1. In case a new needles should be created, add the corresponding `assert_screen` calls
    to your test.
-2. Start the test with the +assert_screen+ calls which are supposed to fail.
-3. Select "+assert_screen+ timeout" under "Pause on screen mismatch" and confirm.
+2. Start the test with the `assert_screen` calls which are supposed to fail.
+3. Select "`assert_screen` timeout" under "Pause on screen mismatch" and confirm.
 4. Wait until the test has paused. There is a button to skip the current timeout to speed
    this up.
 5. A button for accessing the needle editor should occur. It may take a few seconds till
@@ -877,11 +877,11 @@ The parameters treated as assets are as follows. Where you see e.g. `ISO_n`, tha
 * `INITRD` (type `other`)
 
 The values of the above parameters are expected to be the name of a file - or, in the case of
-`REPO_n`, a directory - that exists under the path +/var/lib/openqa/share/factory+ on the openQA
+`REPO_n`, a directory - that exists under the path `/var/lib/openqa/share/factory` on the openQA
 web-UI. That path has subdirectories for each of the asset types, and the file or directory must
 be in the correct subdirectory, so e.g. the file for an asset `HDD_1` must be under
-+/var/lib/openqa/share/factory/hdd+. You may create a subdirectory called +fixed+ for any asset
-type and place assets there (e.g. in +/var/lib/openqa/share/factory/hdd/fixed+ for `hdd`-type
+`/var/lib/openqa/share/factory/hdd`. You may create a subdirectory called `fixed` for any asset
+type and place assets there (e.g. in `/var/lib/openqa/share/factory/hdd/fixed` for `hdd`-type
 assets): this exempts them from the automatic cleanup described under 'Asset cleanup' above.
 Non-fixed assets are always subject to the cleanup.
 
@@ -900,15 +900,15 @@ assets.
 .The following suffixes exist:
 
 _URL:: Before starting these jobs, try to download these assets into the relevant asset directory
-of the openQA web-UI from trusted domains specified in +/etc/openqa/openqa.ini+. For e.g.,
+of the openQA web-UI from trusted domains specified in `/etc/openqa/openqa.ini`. For e.g.,
 `ISO_1_URL=http://trusted.com/foo.iso` would, if `trusted.com` is set as a trusted domain, cause
-openQA to download the file `foo.iso` to +/var/lib/openqa/share/factory/iso+ and set
+openQA to download the file `foo.iso` to `/var/lib/openqa/share/factory/iso` and set
 `ISO_1=foo.iso`. If you set both `ISO_1` and `ISO_1_URL`, the file pointed to by `ISO_1_URL` will
 be downloaded and renamed to the name set as `ISO_1`.
 
 _DECOMPRESS_URL:: Specify a compressed asset to be downloaded that will be uncompressed by openQA.
 For e.g. `ISO_1_DECOMPRESS_URL=http://host/foo2.iso.xz` will download the file `foo2.iso.xz`,
-uncompress it to `foo2.iso`, store it in +/var/lib/openqa/share/factory/iso+ and set
+uncompress it to `foo2.iso`, store it in `/var/lib/openqa/share/factory/iso` and set
 `ISO_1=foo2.iso`. Again, you can also set `ISO_1` to change the name the file will be downloaded
 and uncompressed as.
 
@@ -984,7 +984,7 @@ duration unless the files are still being updated. Keep in mind that this
 behavior is also enabled on local instances and affects all cloned jobs
 (unless cloned into a job group).
 
-'Fixed' assets - those placed in the +fixed+ subdirectory of the relevant
+'Fixed' assets - those placed in the `fixed` subdirectory of the relevant
 asset directory - are counted against the group size limit, but are never
 cleaned up. This is intended for things like base disk images which must
 always be available for a test to work.
@@ -997,13 +997,13 @@ configured under 'Edit job group properties'. It also shows the size of
 assets which belong to that group and not to any other group.
 
 The default size limit for job groups can be adjusted in the
-+default_group_limits+ section of the openQA config file.
+`default_group_limits` section of the openQA config file.
 
 === Configure limit for groupless assets ===
 
 Assets not belonging to jobs within a group are deleted automatically
 after a certain number of days. That duration can be adjusted by setting
-+untracked_assets_storage_duration+ in the +misc_limits+ section of the
+`untracked_assets_storage_duration` in the `misc_limits` section of the
 openQA config to the desired number of days.
 
 In less trivial cases where a common limit is not enough or certain assets
@@ -1025,14 +1025,14 @@ Note that modifications to the file will count against the limit, so if an
 asset was updated within the timespan it will not be removed.
 
 == CLI interface
-Beside the +daemon+ argument to run the actual web service the openQA
-startup script +/usr/share/openqa/script/openqa+ supports further arguments.
+Beside the `daemon` argument to run the actual web service the openQA
+startup script `/usr/share/openqa/script/openqa` supports further arguments.
 
-For a full list of those commands, just invoke +/usr/share/openqa/script/openqa -h+.
-This also works for sub-commands(e.g. +/usr/share/openqa/script/openqa minion -h+,
-+/usr/share/openqa/script/openqa minion job -h+).
+For a full list of those commands, just invoke `/usr/share/openqa/script/openqa -h`.
+This also works for sub-commands(e.g. `/usr/share/openqa/script/openqa minion -h`,
+`/usr/share/openqa/script/openqa minion job -h`).
 
-Note that +prefork+ is only supported for the main web service but not for
+Note that `prefork` is only supported for the main web service but not for
 other services like the live view handler.
 
 == Where to now?

--- a/docs/WritingTests.asciidoc
+++ b/docs/WritingTests.asciidoc
@@ -47,7 +47,7 @@ should be used to create a snapshot of the SUT to rollback to. The following fla
 are supported:
 
 * *fatal*: The whole test suite is aborted if the test module fails. The overall state
-  is set to +failed+.
+  is set to `failed`.
 * *ignore_failure*: If this module fails, it will not affect the overall result at all.
 * *milestone*: After this test succeeds, update the 'lastgood' snapshot.
 * *no_rollback*: Don't roll back to the 'lastgood' snapshot if the test module fails.
@@ -55,7 +55,7 @@ are supported:
 
 See the example below for how to enable a test flag.
 Note that snapshots are only supported by the QEMU backend. When using other backends
-+fatal+ is therefore enabled by default. One can explicitly set it to +0+ to disable
+`fatal` is therefore enabled by default. One can explicitly set it to `0` to disable
 the behavior for all backends even though it is not possible to roll back.
 
 There are several callbacks defined:
@@ -160,8 +160,8 @@ sub run() {
 == Variables
 
 Test case behavior can be controlled via variables. Some basic
-variables like +DISTRI+, +VERSION+, +ARCH+ are always set.
-Others like +DESKTOP+ are defined by the 'Test suites' in the openQA
+variables like `DISTRI`, `VERSION`, `ARCH` are always set.
+Others like `DESKTOP` are defined by the 'Test suites' in the openQA
 web UI.
 Check the existing tests at
 https://github.com/os-autoinst/os-autoinst-distri-opensuse[os-autoinst-distri-opensuse
@@ -175,7 +175,7 @@ Variables are accessible via the *get_var* and *check_var* functions.
 
 Soft and hard failures can be triggered on demand by regular expressions when they match the
 serial output which is done after the test is executed. In case it does not make sense
-to continue the test run even if the current test module does not have the fatal flag, use +fatal+
+to continue the test run even if the current test module does not have the fatal flag, use `fatal`
 as serial failure type, so all subsequent test modules will not be executed if such failure
 was detected.
 
@@ -183,7 +183,7 @@ To use this functionality the test developer needs to define the patterns to
 look for in the serial output either in the main.pm or in the test itself.
 Any pattern change done in a test it will be reflected in the next tests.
 
-The patterns defined in +main.pm+ will be valid for all the tests.
+The patterns defined in `main.pm` will be valid for all the tests.
 
 To simplify tests results review, if job fails with the same message, which is defined
 for the pattern, as previous job, automatic comment carryover will work even if
@@ -276,26 +276,26 @@ In short, writing multi-machine tests adds a few more layers of complexity:
 There are different dependency *types* (see subsequent section). Additionally, dependencies can be machine-specific (see "Inter-machine dependencies" section).
 
 ===== Dependency types
-There are 3 types of dependencies: +CHAINED+, +DIRECTLY_CHAINED+ and +PARALLEL+
+There are 3 types of dependencies: `CHAINED`, `DIRECTLY_CHAINED` and `PARALLEL`
 
 ====== Chained dependencies
-+CHAINED+ and +DIRECTLY_CHAINED+ describe when one test case depends on another and both are run sequentially, i.e. KDE test suite is run after and only after Installation test suite is successfully finished and cancelled if fail.
+`CHAINED` and `DIRECTLY_CHAINED` describe when one test case depends on another and both are run sequentially, i.e. KDE test suite is run after and only after Installation test suite is successfully finished and cancelled if fail.
 
-The difference between +CHAINED+ and +DIRECTLY_CHAINED+ dependencies is that +DIRECTLY_CHAINED+ means the tests must run directly after another on the same worker slot.
+The difference between `CHAINED` and `DIRECTLY_CHAINED` dependencies is that `DIRECTLY_CHAINED` means the tests must run directly after another on the same worker slot.
 This can be useful to test efficiently on bare metal SUTs and other self-provisioning environments.
 
-To define a +CHAINED+ dependency add the variable +START_AFTER_TEST+ with the name(s) of test suite(s) after which the selected test suite is supposed to run.
-Use comma separated list for multiple test suite dependency. E.g. +START_AFTER_TEST="kde,dhcp-server"+
+To define a `CHAINED` dependency add the variable `START_AFTER_TEST` with the name(s) of test suite(s) after which the selected test suite is supposed to run.
+Use comma separated list for multiple test suite dependency. E.g. `START_AFTER_TEST="kde,dhcp-server"`
 
-To define a +DIRECTLY_CHAINED+ dependency add the variable +START_DIRECTLY_AFTER_TEST+. It works in the same way as for +CHAINED+ dependencies. Mismatching worker classes between jobs to run in direct sequence on the same worker are considered an error.
+To define a `DIRECTLY_CHAINED` dependency add the variable `START_DIRECTLY_AFTER_TEST`. It works in the same way as for `CHAINED` dependencies. Mismatching worker classes between jobs to run in direct sequence on the same worker are considered an error.
 
 ====== Parallel dependencies
-+PARALLEL+ describes multi-machine tests. That are test suites scheduled to run at the same time and managed as a group. On top of that, +PARALLEL+ also describes
+`PARALLEL` describes multi-machine tests. That are test suites scheduled to run at the same time and managed as a group. On top of that, `PARALLEL` also describes
 test suite dependencies, where some test suites (children) run parallel with other test suites (parents) only when parents are running.
 
-To define a +PARALLEL+ dependency, use the +PARALLEL_WITH+ variable with the name(s) of test suite(s) which acts as a parent suite(s) to selected test suite.
-In other words, +PARALLEL_WITH+ describes "I need this test suite to be running during my run". Use a comma separated list for multiple test suite dependency
-(e.g. +PARALLEL_WITH="web-server,dhcp-server"+).
+To define a `PARALLEL` dependency, use the `PARALLEL_WITH` variable with the name(s) of test suite(s) which acts as a parent suite(s) to selected test suite.
+In other words, `PARALLEL_WITH` describes "I need this test suite to be running during my run". Use a comma separated list for multiple test suite dependency
+(e.g. `PARALLEL_WITH="web-server,dhcp-server"`).
 Keep in mind that the parent job _must be running until all children finish_. Otherwise the scheduler will cancel child jobs once parent is done.
 
 Job dependencies are only resolved when using the iso controller to
@@ -305,8 +305,8 @@ won't work.
 ===== Inter-machine dependencies
 Those dependencies make it possible to create job dependencies between tests which are supposed to run on different machines.
 
-To use it, simply append the machine name for each dependent test suite with an +@+ sign separated.
-If a machine is not explicitly defined, the variable +MACHINE+ of the current job is used for the dependent test suite.
+To use it, simply append the machine name for each dependent test suite with an `@` sign separated.
+If a machine is not explicitly defined, the variable `MACHINE` of the current job is used for the dependent test suite.
 
 Example 1:
 
@@ -327,15 +327,15 @@ By default, when a parallel *child* fails or is cancelled, the parent and all ot
 
 ===== Examples
 ====== Specify machine explicitly
-Assume there is a test suite +A+ supposed to run on machine +64bit-8G+. Additionally, test suite +B+ supposed to run on machine +64bit-1G+.
-That means test suite +B+ needs the variable +START_AFTER_TEST=A@64bit-8G+. This results in the following dependency:
+Assume there is a test suite `A` supposed to run on machine `64bit-8G`. Additionally, test suite `B` supposed to run on machine `64bit-1G`.
+That means test suite `B` needs the variable `START_AFTER_TEST=A@64bit-8G`. This results in the following dependency:
 ----
 A@64bit-8G --> B@64bit-1G
 ----
 
 ====== Implicitly inherit machines from parent
-Assume test suite +A+ is supposed to run on the machines +64bit+ and +ppc+. Additionally, test suite +B+ is supposed to run on both of these
-machines as well. This can be achieved by simply adding the variable +START_AFTER_TEST=A+ to test suite +B+ (omitting the machine at all).
+Assume test suite `A` is supposed to run on the machines `64bit` and `ppc`. Additionally, test suite `B` is supposed to run on both of these
+machines as well. This can be achieved by simply adding the variable `START_AFTER_TEST=A` to test suite `B` (omitting the machine at all).
 openQA take the best matches. This results in the following dependencies:
 
 ----
@@ -344,15 +344,15 @@ A@ppc --> B@ppc
 ----
 
 ====== Conflicting machines prevent inheritence from parent
-Assume test suite +A+ is supposed to run on machine +64bit-8G+. Additionally, test suite +B+ is supposed to run on machine +64bit-1G+.
+Assume test suite `A` is supposed to run on machine `64bit-8G`. Additionally, test suite `B` is supposed to run on machine `64bit-1G`.
 
-Adding the variable +START_AFTER_TEST=A+ to test suite +B+ will *not* work. That means openQA will *not* create a job dependency and instead shows
-an error message. So it is required to explicitly define the variable as +START_AFTER_TEST=A@64bit-8G+ in that case.
+Adding the variable `START_AFTER_TEST=A` to test suite `B` will *not* work. That means openQA will *not* create a job dependency and instead shows
+an error message. So it is required to explicitly define the variable as `START_AFTER_TEST=A@64bit-8G` in that case.
 
-Consider a different example: Assume test suite +A+ is supposed to run on the machines +ppc+, +64bit+ and +s390x+. Additionally, there are 3
-testsuites +B+ on +ppc-1G+, +C+ on +ppc-2G+ and +D+ on +ppc64le+.
+Consider a different example: Assume test suite `A` is supposed to run on the machines `ppc`, `64bit` and `s390x`. Additionally, there are 3
+testsuites `B` on `ppc-1G`, `C` on `ppc-2G` and `D` on `ppc64le`.
 
-Adding the variable +PARALLEL_WITH=A@ppc+ to the test suites +B+, +C+ and +D+ will result in the following dependencies:
+Adding the variable `PARALLEL_WITH=A@ppc` to the test suites `B`, `C` and `D` will result in the following dependencies:
 
 ----
             A@ppc
@@ -362,16 +362,16 @@ Adding the variable +PARALLEL_WITH=A@ppc+ to the test suites +B+, +C+ and +D+ wi
 B@ppc-1G  C@ppc-2G  D@ppc64le
 ----
 
-openQA will also show errors that test suite +A+ is not necessary on the machines +64bit+ and +s390x+.
+openQA will also show errors that test suite `A` is not necessary on the machines `64bit` and `s390x`.
 
 ====== Implicitly creating a dependency on same machine
-Assume the value of the variable +START_AFTER_TEST+ or +PARALLEL_WITH+ *only* contains a test suite name but no
-machine (e.g. +START_AFTER_TEST=A,B+ or +PARALLEL_WITH=A,B+).
+Assume the value of the variable `START_AFTER_TEST` or `PARALLEL_WITH` *only* contains a test suite name but no
+machine (e.g. `START_AFTER_TEST=A,B` or `PARALLEL_WITH=A,B`).
 
 In this case openQA will create job dependencies that are scheduled on the same machine if all test suites are placed on the same machine.
 
 ===== Notes regarding directly chained dependencies
-Having multiple jobs with +START_DIRECTLY_AFTER_TEST+ pointing to the same parent job is possible, e.g.:
+Having multiple jobs with `START_DIRECTLY_AFTER_TEST` pointing to the same parent job is possible, e.g.:
 ----
    --> B --> C
  /
@@ -380,21 +380,21 @@ A
    --> D --> E
 ----
 
-Of course only either +B+ or +D+ jobs can really be started *directly* after +A+. However, the use of +START_DIRECTLY_AFTER_TEST+ still makes sure that no completely different job is executed in the middle and of course that all of these jobs are executed on the same worker.
+Of course only either `B` or `D` jobs can really be started *directly* after `A`. However, the use of `START_DIRECTLY_AFTER_TEST` still makes sure that no completely different job is executed in the middle and of course that all of these jobs are executed on the same worker.
 
-The directly chained sub-trees are executed in alphabetical order. So the above tree would result in the following execution order: +A, B, C, D, E+.
+The directly chained sub-trees are executed in alphabetical order. So the above tree would result in the following execution order: `A, B, C, D, E`.
 
-If +A+ fails, none of the other jobs are attempted to be executed. If +B+ fails, +C+ is not attempted to be executed but +D+ and +E+ are. The assumption is that the average error case does not leave the system in a completely broken state and possibly required cleanup is done in the post fail hook.
+If `A` fails, none of the other jobs are attempted to be executed. If `B` fails, `C` is not attempted to be executed but `D` and `E` are. The assumption is that the average error case does not leave the system in a completely broken state and possibly required cleanup is done in the post fail hook.
 
 Directly chained dependencies and regularly chained dependencies can be mixed. This allows to create a dependency tree which contains multiple directly chained sub-trees. Be aware that these sub-trees might be executed on *different* workers and depending on the tree even be executed in parallel.
 
 ===== Worker requirements
-+CHAINED+ and +DIRECTLY_CHAINED+ dependencies require only one worker. +PARALLEL+ dependencies on the other hand require as many free workers as jobs are present in the
+`CHAINED` and `DIRECTLY_CHAINED` dependencies require only one worker. `PARALLEL` dependencies on the other hand require as many free workers as jobs are present in the
 parallel cluster.
 
 ====== Examples
 
-.+CHAINED+ - i.e. test basic functionality before going advanced - requires 1 worker
+.`CHAINED` - i.e. test basic functionality before going advanced - requires 1 worker
 ----
 A --> B --> C
 
@@ -408,7 +408,7 @@ and then define C with START_AFTER_TEST=A,B
 In this case however the start order of A and B is not specified.
 But C will start only after A and B are successfully done.
 ----
-.+PARALLEL+ basic High-Availability
+.`PARALLEL` basic High-Availability
 ----
 A
 ^
@@ -418,7 +418,7 @@ Define test suite A
 and then define B with variable PARALLEL_WITH=A.
 A in this case is parent test suite to B and must be running throughout B run.
 ----
-.+PARALLEL+ with multiple parents - i.e. complex support requirements for one test - requires 4 workers
+.`PARALLEL` with multiple parents - i.e. complex support requirements for one test - requires 4 workers
 ----
 A B C
 \ | /
@@ -429,7 +429,7 @@ Define test suites A,B,C
 and then define D with PARALLEL_WITH=A,B,C.
 A,B,C run in parallel and are parent test suites for D and all must run until D finish.
 ----
-.+PARALLEL+ with one parent - i.e. running independent tests against one server - requires at least 2 workers
+.`PARALLEL` with one parent - i.e. running independent tests against one server - requires at least 2 workers
 ----
    A
    ^
@@ -444,21 +444,21 @@ Children B, C, D can run and finish anytime, but A must run until all B, C, D fi
 
 === Test synchronization and locking API
 
-OpenQA provides a locking API. To use it in your test files import the +lockapi+ package (_use lockapi;_). It provides the following functions: +mutex_create+, +mutex_lock+, +mutex_unlock+, +mutex_wait+
+OpenQA provides a locking API. To use it in your test files import the `lockapi` package (_use lockapi;_). It provides the following functions: `mutex_create`, `mutex_lock`, `mutex_unlock`, `mutex_wait`
 
 Each of these functions takes the name of the mutex lock as first parameter. The name must not contain the "-" character. Mutex locks are associated with the caller's job.
 
-+mutex_lock+ tries to lock the mutex for the caller's job. The +mutex_lock+ call blocks if the mutex does not exist or has been locked by a different job.
+`mutex_lock` tries to lock the mutex for the caller's job. The `mutex_lock` call blocks if the mutex does not exist or has been locked by a different job.
 
-+mutex_unlock+ tries to unlock the mutex. If the mutex is locked by a different job, +mutex_unlock+ call blocks until the lock becomes available. If the mutex does not exist the call returns immediately without doing anything.
+`mutex_unlock` tries to unlock the mutex. If the mutex is locked by a different job, `mutex_unlock` call blocks until the lock becomes available. If the mutex does not exist the call returns immediately without doing anything.
 
-+mutex_wait+ is a combination of +mutex_lock+ and +mutex_unlock+. It displays more information about mutex state (time spent waiting, location of the lock). Use it if you need to wait for a specific action from single place (e.g. that Apache is running on the master node).
+`mutex_wait` is a combination of `mutex_lock` and `mutex_unlock`. It displays more information about mutex state (time spent waiting, location of the lock). Use it if you need to wait for a specific action from single place (e.g. that Apache is running on the master node).
 
-+mutex_create+ creates a new mutex which is initially unlocked. If the mutex already exists the call returns immediately without doing anything.
+`mutex_create` creates a new mutex which is initially unlocked. If the mutex already exists the call returns immediately without doing anything.
 
 Mutexes are addressed by _their name_. Each cluster of parallel jobs (defined via `PARALLEL_WITH` dependencies) has its own namespace. That means concurrently running jobs in different parallel job clusters use distinct mutexes (even if the same names are used).
 
-The +mmapi+ package provides +wait_for_children+ which the parent can use to wait for the children to complete.
+The `mmapi` package provides `wait_for_children` which the parent can use to wait for the children to complete.
 
 [caption="Example of mutex usage"]
 ====
@@ -513,9 +513,9 @@ Sometimes it is useful to wait for a certain action from the child or sibling jo
 In this case the child or sibling will create a mutex and any cluster job can lock/unlock it.
 
 The child can however die at any time. To prevent parent deadlock in this situation,
-it is required to pass the mutex owner's job ID as a second parameter to +mutex_lock+ and +mutex_wait+.
+it is required to pass the mutex owner's job ID as a second parameter to `mutex_lock` and `mutex_wait`.
 The mutex owner is the job that creates the mutex.
-If a child job with a given ID has already finished, +mutex_lock+ calls die.
+If a child job with a given ID has already finished, `mutex_lock` calls die.
 The job ID is also required when unlocking such a mutex.
 
 [caption="Example of mmapi: Parent Job"]
@@ -544,18 +544,18 @@ sub run {
 Mutexes are a way to wait for specific events from a single job.
 When we need multiple jobs to reach a certain state we need to use barriers.
 
-To create a barrier call +barrier_create+ with the parameters name and count.
+To create a barrier call `barrier_create` with the parameters name and count.
 The name serves as an ID (same as with mutexes). The count parameter specifies the
-number of jobs needed to call +barrier_wait+ to unlock barrier.
+number of jobs needed to call `barrier_wait` to unlock barrier.
 
-There is an optional +barrier_wait+ parameter called +check_dead_job+.
-When used it will kill all jobs waiting in +barrier_wait+ if one of the cluster jobs
+There is an optional `barrier_wait` parameter called `check_dead_job`.
+When used it will kill all jobs waiting in `barrier_wait` if one of the cluster jobs
 dies. It prevents waiting for states that will never be reached (and eventually dies
-on job timeout). It should be set only on one of the +barrier_wait+ calls.
+on job timeout). It should be set only on one of the `barrier_wait` calls.
 
 An example would be one master and three worker jobs and you want to do initial setup
 in the three worker jobs before starting main actions. In such a case you might use
-+check_dead_job+ to avoid useless actions when one of the worker jobs dies.
+`check_dead_job` to avoid useless actions when one of the worker jobs dies.
 
 
 [caption="Example of barriers: "]
@@ -684,13 +684,13 @@ SUPPORT_SERVER_ROLES=pxe,qemuproxy
 WORKER_CLASS=server,qemu_autoyast_tap_64
 --------------------------------------------------------------------------------
 
-where the +SUPPORT_SERVER_ROLES+ defines the specific role (see code in 'tests/support_server/setup.pm' for available roles and their definition), and
- +HDD_1+ variable must be the name of the supportserver image as defined via +PUBLISH_HDD_1+ variable during supportserver generation. If the support
-server is based on older SUSE versions (opensuse 11.x, SLE11SP4..) it may also be needed to add +HDDMODEL=virtio-blk+. In case of QEMU backend, one can
-also use +BOOTFROM=c+, for faster boot directly from the +HDD_1+ image.
+where the `SUPPORT_SERVER_ROLES` defines the specific role (see code in 'tests/support_server/setup.pm' for available roles and their definition), and
+ `HDD_1` variable must be the name of the supportserver image as defined via `PUBLISH_HDD_1` variable during supportserver generation. If the support
+server is based on older SUSE versions (opensuse 11.x, SLE11SP4..) it may also be needed to add `HDDMODEL=virtio-blk`. In case of QEMU backend, one can
+also use `BOOTFROM=c`, for faster boot directly from the `HDD_1` image.
 
 Then for the 'child' test using this supportserver, the following additional variable must be set:
-+PARALLEL_WITH=supportserver-pxe-tftp+
+`PARALLEL_WITH=supportserver-pxe-tftp`
 where 'supportserver-pxe-tftp' is the name given to the supportserver in the test suites screen.
 Once the tests are defined, they can be added to openQA in the usual way:
 
@@ -700,8 +700,8 @@ Once the tests are defined, they can be added to openQA in the usual way:
         ISO=openSUSE-13.2-DVD-x86_64.iso ARCH=x86_64 FLAVOR=Server-DVD
 -----------------
 
-where the +DISTRI+, +VERSION+, +FLAVOR+ and +ARCH+ correspond to the job group containing the tests.
-Note that the networking is provided by tap devices, so both jobs should run on machines defined by (apart from others) having +NICTYPE=tap+, +WORKER_CLASS=qemu_autoyast_tap_64+.
+where the `DISTRI`, `VERSION`, `FLAVOR` and `ARCH` correspond to the job group containing the tests.
+Note that the networking is provided by tap devices, so both jobs should run on machines defined by (apart from others) having `NICTYPE=tap`, `WORKER_CLASS=qemu_autoyast_tap_64`.
 
 
 [caption="Example of Support Server: "]
@@ -718,9 +718,9 @@ WORKER_CLASS=server,qemu_autoyast_tap_64
 --------------------------------------------------------------------------------
 ====
 
-With a test-suites name +supportserver-opensuse-tftp+.
+With a test-suites name `supportserver-opensuse-tftp`.
 
-The actual test 'child' job, will then have to set +PARALLEL_WITH=supportserver-opensuse-tftp+, and also other variables according to the test requirements. For convenience, we have also started a dhcp server on the supportserver, but even without it, network could be set up manually by assigning a free ip address (e.g. 10.0.2.15) on the system of the test job.
+The actual test 'child' job, will then have to set `PARALLEL_WITH=supportserver-opensuse-tftp`, and also other variables according to the test requirements. For convenience, we have also started a dhcp server on the supportserver, but even without it, network could be set up manually by assigning a free ip address (e.g. 10.0.2.15) on the system of the test job.
 
 [caption="Example of Support Server: "]
 .The code in the *.pm module doing the actual tftp test could then look something like the example below
@@ -772,10 +772,10 @@ PARALLEL_WITH=supportserver-opensuse-tftp
 --------------------------------------------------------------------------------
 ====
 
-again assuming the support server's name being +supportserver-opensuse-tftp+. Note that the +pxe+ role already contains +tftp+ and +dhcp+ server role, since they are needed for the pxe boot to work.
+again assuming the support server's name being `supportserver-opensuse-tftp`. Note that the `pxe` role already contains `tftp` and `dhcp` server role, since they are needed for the pxe boot to work.
 
 [caption="Example of Support Server: "]
-.The tftp test defined in the +autoyast_opensuse/opensuse_autoyast_tftp.sh+ file could be something like:
+.The tftp test defined in the `autoyast_opensuse/opensuse_autoyast_tftp.sh` file could be something like:
 ====
 [source,sh]
 --------------------------------------------------------------------------------
@@ -786,7 +786,7 @@ time tftp #SERVER_URL# -c get test2.txt
 diff -u test.txt test2.txt && echo "AUTOYAST OK"
 --------------------------------------------------------------------------------
 
-and the rest is done automatically, using already prepared test modules in +tests/autoyast+ subdirectory.
+and the rest is done automatically, using already prepared test modules in `tests/autoyast` subdirectory.
 ====
 
 === Using text consoles and the serial terminal
@@ -803,7 +803,7 @@ implemented with VNC and so I will referrer to it as the VNC text console.
 
 The serial port device which is used with the VNC text console is the default
 virtual serial port device in QEMU (i.e. the device configured with the
-+-serial+ command line option). I will refer to this as the "default serial
+`-serial` command line option). I will refer to this as the "default serial
 port". OpenQA currently only uses this serial port for one way communication
 from the SUT to the host.
 
@@ -814,7 +814,7 @@ machine. This is called the serial terminal console (or the virtio console,
 see implementation section for details).
 
 The VNC text console is very slow and expensive relative to the serial
-terminal console, but allows you to continue using +assert_screen+ and is more
+terminal console, but allows you to continue using `assert_screen` and is more
 widely supported. Below is an example of how to use the VNC text console.
 
 [caption="Switching to text mode: "]
@@ -841,15 +841,15 @@ This will select a text TTY and login as the root user (if necessary). Now
 that we are on a text console it is possible to run scripts and observe their
 output either as raw text or on the video feed.
 
-Note that +root-console+ is defined by the distribution, so on different
+Note that `root-console` is defined by the distribution, so on different
 distributions or operating systems this can vary. There are also many utility
-functions that wrap +select_console+, so check your distribution's utility
+functions that wrap `select_console`, so check your distribution's utility
 library before using it directly.
 
 ====
 
 [caption="Running a script: "]
-.Using the +assert_script_run+ and +script_output+ commands
+.Using the `assert_script_run` and `script_output` commands
 ====
 [source,perl]
 --------------------------------------------------------------------------------
@@ -868,19 +868,19 @@ and then searches it for the term 'avx2' using a regex.
 
 ====
 
-The +script_run+ and +script_output+ are high level commands which use
-+type_string+ and +wait_serial+ underneath. Sometimes you may wish to use
+The `script_run` and `script_output` are high level commands which use
+`type_string` and `wait_serial` underneath. Sometimes you may wish to use
 lower level commands which give you more control, but be warned that it may
 also make your code less portable.
 
-The command +wait_serial+ watches the SUT's serial port for text output and
-matches it against a regex. +type_string+ sends a string to the SUT like it
+The command `wait_serial` watches the SUT's serial port for text output and
+matches it against a regex. `type_string` sends a string to the SUT like it
 was typed in by the user over VNC.
 
 ==== Using a serial terminal
 
 IMPORTANT: You need a QEMU version >= 2.6.1 and to set the
-+VIRTIO_CONSOLE+ variable to 1 to use this with the QEMU backend.
+`VIRTIO_CONSOLE` variable to 1 to use this with the QEMU backend.
 
 Usually OpenQA controls the system under test using VNC. This allows the use
 of both graphical and text based consoles. Key presses are sent individually
@@ -897,7 +897,7 @@ also much cheaper to transfer text and test it against regular expressions
 than encode images from a VNC feed and test them against sample images
 (needles).
 
-On the other hand you can no longer use +assert_screen+ or take a screen shot
+On the other hand you can no longer use `assert_screen` or take a screen shot
 because the text is never rendered as an image. A lot of programs will also
 send ANSI escape sequences which will appear as raw text to the test script
 instead of being interpreted by a terminal emulator which then renders the
@@ -908,10 +908,10 @@ text.
 select_console('root-virtio-terminal');  # Selects a virtio based serial terminal
 --------------------------------------------------------------------------------
 
-The above code will cause +type_string+ and +wait_serial+ to write and read
+The above code will cause `type_string` and `wait_serial` to write and read
 from a virtio serial port. A distribution specific call back will be made
 which allows os-autoinst to log into a serial terminal session running on the
-SUT. Once +select_console+ returns you should be logged into a TTY as root.
+SUT. Once `select_console` returns you should be logged into a TTY as root.
 
 NOTE: for https://github.com/os-autoinst/os-autoinst-distri-opensuse[os-autoinst-distri-opensuse]
 tests instead of using `select_console('root-virtio-terminal')` directly is
@@ -928,28 +928,28 @@ select_serial_terminal();
 If you are struggling to visualise what is happening, imagine SSH-ing into a
 remote machine as root, you can then type in commands and read the results as
 if you were sat at that computer. What we are doing is much simpler than using
-an SSH connection (it is more like using GNU +screen+ with a serial port), but
+an SSH connection (it is more like using GNU `screen` with a serial port), but
 the end result looks quite similar.
 
 As mentioned above, changing input and output to a serial terminal has the
-effect of changing where +wait_serial+ reads output from. On a QEMU VM
-+wait_serial+ usually reads from the default serial port which is also where
+effect of changing where `wait_serial` reads output from. On a QEMU VM
+`wait_serial` usually reads from the default serial port which is also where
 the kernel log is usually output to.
 
-When switching to a virtio based serial terminal, +wait_serial+ will then read
+When switching to a virtio based serial terminal, `wait_serial` will then read
 from a virtio serial port instead. However the default serial port still
 exists and can receive output. Some utility library functions are hard coded
-to redirect output to the default serial port and expect that +wait_serial+
+to redirect output to the default serial port and expect that `wait_serial`
 will be able to read it. Usually it is not too difficult to fix the utility
 function, you just need to remove some redirection from the relevant shell
 command.
 
 Another common problem is that some library or utility function tries to take
 a screen shot. The hard part is finding what takes the screen shot, but then
-it is just a simple case of checking +is_serial_terminal+ and not taking the
+it is just a simple case of checking `is_serial_terminal` and not taking the
 screen shot if we are on a serial terminal console.
 
-Distributions usually wrap +select_console+, so instead of using it directly,
+Distributions usually wrap `select_console`, so instead of using it directly,
 you can use something like the following which is from the OpenSUSE test
 suite.
 
@@ -962,24 +962,24 @@ if (select_serial_terminal()) {
 
 This selects the virtio based serial terminal console if possible. If it is
 available then it returns true. It is also possible to check if the current
-console is a serial terminal by calling +is_serial_terminal+.
+console is a serial terminal by calling `is_serial_terminal`.
 
 Once you have selected a serial terminal, the video feed will disappear from
 the live view, however at the bottom of the live screen there is a separate
 text feed. After the test has finished you can view the serial log(s) in the
-assets tab. You will probably have two serial logs; +serial0.txt+ which is
-written from the default serial port and +serial_terminal.txt+.
+assets tab. You will probably have two serial logs; `serial0.txt` which is
+written from the default serial port and `serial_terminal.txt`.
 
 Now that you are on a serial terminal console everything will start to go a
 lot faster. So much faster in fact that race conditions become a big
 issue. Generally these can be avoided by using the higher level functions such
-as +script_run+ and +script_output+.
+as `script_run` and `script_output`.
 
 It is rarely necessary to use the lower level functions, however it helps to
 recognise problems caused by race conditions at the lower level, so please
 read the following section regardless.
 
-So if you do need to use +type_string+ and +wait_serial+ directly then try to
+So if you do need to use `type_string` and `wait_serial` directly then try to
 use the following pattern:
 
 1) Wait for the terminal prompt to appear.
@@ -1012,10 +1012,10 @@ if (is_serial_terminal) {
 my $test_log = wait_serial(qr/$fin_msg\d+/, $timeout, 0, record_output => 1); #Step 5
 --------------------------------------------------------------------------------
 
-The first +wait_serial+ (Step 1) ensures that the shell prompt has
+The first `wait_serial` (Step 1) ensures that the shell prompt has
 appeared. If we do not wait for the shell prompt then it is possible that we
 can send input to whatever command was run before. In this case that command
-would be 'echo' which is used by +script_run+ to print a 'finished' message.
+would be 'echo' which is used by `script_run` to print a 'finished' message.
 
 It is possible that echo was able to print the finish message, but was then
 suspended by the OS before it could exit. In which case the test script is
@@ -1028,19 +1028,19 @@ this results in the input being displayed twice: once by the terminal's echo
 (explained later) and once by Bash. Depending on your configuration the
 behavior could be completely different
 
-The function +serial_term_prompt+ is a distribution specific function which
+The function `serial_term_prompt` is a distribution specific function which
 returns the characters previously set as the shell prompt (e.g. export PS1="#
 ", see the bash(1) or dash(1) man pages). If you are adapting a new
 distribution to use the serial terminal console, then we recommend setting a
 simple shell prompt and keeping track of it with utility functions.
 
-The +no_regex+ argument tells wait_serial to use simple string matching
+The `no_regex` argument tells wait_serial to use simple string matching
 instead of regular expressions, see the implementation section for more
-details. The other arguments are the timeout (+undef+ means we use the
-default) and a boolean which inverts the result of +wait_serial+. These are
-explained in the +os-autoinst/testapi.pm+ documentation.
+details. The other arguments are the timeout (`undef` means we use the
+default) and a boolean which inverts the result of `wait_serial`. These are
+explained in the `os-autoinst/testapi.pm` documentation.
 
-Then the test script enters our command with +type_string+ (Step 2) and waits
+Then the test script enters our command with `type_string` (Step 2) and waits
 for the command's text to be echoed back by the system under test. Terminals
 usually echo back the characters sent to them so that the user can see what
 they have typed.
@@ -1061,12 +1061,12 @@ any string which results in a significant state change should be treated as a
 potential source of race conditions.
 
 Finally we send the newline character and wait for our custom finish
-message. +record_output+ is set to ensure all the output from the SUT is
+message. `record_output` is set to ensure all the output from the SUT is
 saved (see the next section for more info).
 
 What we do *not* do at this point, is wait for the shell prompt to appear.
 That would consume the prompt character breaking the next call to
-+script_run+.
+`script_run`.
 
 We choose to wait for the prompt just before sending a command, rather than
 after it, so that Step 5 can be deferred to a later time. In theory this
@@ -1074,8 +1074,8 @@ allows the test script to perform some other work while the SUT is busy.
 
 ==== Sending new lines and continuation characters
 
-The following command will timeout: +script_run("echo \"1\n2\"")+. The reason
-being +script_run+ will call +wait_serial("echo \"1\n2\"")+ to check that the
+The following command will timeout: `script_run("echo \"1\n2\"")`. The reason
+being `script_run` will call `wait_serial("echo \"1\n2\"")` to check that the
 command was entered successfully and echoed back (see above for explanation of
 serial terminal echo, note the echo shell command has not been executed
 yet). However the shell will translate the newline characters into a newline
@@ -1088,17 +1088,17 @@ echo "1
 --------------------------------------------------------------------------------
 
 The '>' is unexpected and will cause the match to fail. One way to fix this is
-simply to do +echo -e \"1\\n2\"+. In this case Perl will not replace \n with a
+simply to do `echo -e \"1\\n2\"`. In this case Perl will not replace \n with a
 newline character, instead it will be passed to echo which will do the
 substitution instead (note the '-e' switch for echo).
 
 In general you should be aware that, Perl, the guest kernel and the shell may
 transform whatever character sequence you enter. Transformations can be
-spotted by comparing the input string with what +wait_serial+ actually finds.
+spotted by comparing the input string with what `wait_serial` actually finds.
 
 ==== Sending signals - ctrl-c and ctrl-d
 
-On a VNC based console you simply use +send_key+ like follows.
+On a VNC based console you simply use `send_key` like follows.
 
 [source,perl]
 --------------------------------------------------------------------------------
@@ -1109,7 +1109,7 @@ This usually (see termios(3)) has the effect of sending SIGINT to whatever
 command is running. Most commands terminate upon receiving this signal (see
 signal(7)).
 
-On a serial terminal console the +send_key+ command is not implemented (see
+On a serial terminal console the `send_key` command is not implemented (see
 implementation section). So instead the following can be done to achieve the
 same effect.
 
@@ -1119,19 +1119,19 @@ type_string('', terminate_with => 'ETX');
 --------------------------------------------------------------------------------
 
 The ETX ASCII code means End of Text and usually results in SIGINT being
-raised. In fact pressing +ctrl-c+ may just be translated into ETX, so you
+raised. In fact pressing `ctrl-c` may just be translated into ETX, so you
 might consider this a more direct method. Also you can use 'EOT' to do the
-same thing as pressing +ctrl-d+.
+same thing as pressing `ctrl-d`.
 
 You also have the option of using Perl's control character escape sequences in
-the first argument to +type_string+. So you can also send ETX with:
+the first argument to `type_string`. So you can also send ETX with:
 
 [source,perl]
 --------------------------------------------------------------------------------
 type_string("\cC");
 --------------------------------------------------------------------------------
 
-The +terminate_with+ parameter just exists to display intention. It is also
+The `terminate_with` parameter just exists to display intention. It is also
 possible to send any character using the hex code like '\x0f' which may have
 the effect of pressing the magic SysRq key if you are lucky.
 
@@ -1146,31 +1146,31 @@ and distribution.pm.
 You may find it useful to read the documentation in virtio_terminal.pm and
 serial_screen.pm if you need to perform some special action on a terminal such
 as triggering a signal or simulating the SysRq key. There are also some
-console specific arguments to +wait_serial+ and +type_string+ such as
-+record_output+.
+console specific arguments to `wait_serial` and `type_string` such as
+`record_output`.
 
 The virtio 'screen' essentially reads data from a socket created by QEMU into
 a ring buffer and scans it after every read with a regular expression. The
 ring buffer is large enough to hold anything you are likely to want to match
 against, but not too large as to cause performance issues. Usually the
 contents of this ring buffer, up to the end of the match, are returned by
-+wait_serial+. This means earlier output will be overwritten once the ring
-buffer's length is exceeded. However you can pass +record_output+ which saves
+`wait_serial`. This means earlier output will be overwritten once the ring
+buffer's length is exceeded. However you can pass `record_output` which saves
 the output to a separate unlimited buffer and returns that instead.
 
-Like +record_output+, the +no_regex+ argument is a console specific argument
+Like `record_output`, the `no_regex` argument is a console specific argument
 supported by the serial terminal console. It may or may not have some
 performance benefits, but more importantly it allows you to easily match
 arbitrary strings which may contain regex escape sequences. To be clear,
-+no_regex+ hints that +wait_serial+ should just treat its input as a plain
-string and use the Perl library function +index+ to search for a match in the
+`no_regex` hints that `wait_serial` should just treat its input as a plain
+string and use the Perl library function `index` to search for a match in the
 ring buffer.
 
-The +send_key+ function is not implemented for the serial terminal console
+The `send_key` function is not implemented for the serial terminal console
 because the OpenQA console implementation would need to map key actions like
-+ctrl-c+ to a character and then send that character. This may mislead some
-people into thinking they are actually sending +ctrl-c+ to the SUT and also
-requires OpenQA to choose what character +ctrl-c+ represents which varies
+`ctrl-c` to a character and then send that character. This may mislead some
+people into thinking they are actually sending `ctrl-c` to the SUT and also
+requires OpenQA to choose what character `ctrl-c` represents which varies
 across terminal configurations.
 
 Very little of the code (perhaps none) is specific to a virtio based serial
@@ -1184,7 +1184,7 @@ console' unless specifically referring to the QEMU virtio implementation.
 As mentioned previously, ANSI escape sequences can be a pain. So we try to
 avoid them by informing the shell that it is running on a 'dumb' terminal (see
 the SUSE distribution's serial terminal utility library). However some
-programs ignore this, but piping there output into +tee+ is usually enough to
+programs ignore this, but piping there output into `tee` is usually enough to
 stop them outputting non-printable characters.
 
 
@@ -1192,10 +1192,10 @@ stop them outputting non-printable characters.
 === Trigger new tests by modifying settings from existing test runs
 
 To trigger new tests with custom settings the command line client
-+openqa-client+ can be used. To trigger new tests relying on all settings from
-existing tests runs but modifying specific settings the +openqa-clone-job+
+`openqa-client` can be used. To trigger new tests relying on all settings from
+existing tests runs but modifying specific settings the `openqa-clone-job`
 script can be used. Within the openQA repository the script is located at
-+/usr/share/openqa/script/+.  This tool can be used to create a new job that
+`/usr/share/openqa/script/`.  This tool can be used to create a new job that
 adds, removes or changes settings.
 
 [source,sh]
@@ -1205,7 +1205,7 @@ openqa-clone-job --from localhost --host localhost 42 FOO=bar BAZ=
 
 If you do not want a cloned job to start up in the same job group as the job
 you cloned from, e.g. to not pollute build results, the job group can be
-overwritten, too, using the special variable +_GROUP+. Add the quoted group
+overwritten, too, using the special variable `_GROUP`. Add the quoted group
 name, e.g.:
 
 [source,sh]
@@ -1213,7 +1213,7 @@ name, e.g.:
 openqa-clone-job --from localhost 42 _GROUP="openSUSE Tumbleweed"
 -------------
 
-The special group value +0+ means that the group connection will be separated
+The special group value `0` means that the group connection will be separated
 and the job will not appear as a job in any job group, e.g.:
 
 [source,sh]
@@ -1223,13 +1223,13 @@ openqa-clone-job --from localhost 42 _GROUP=0
 
 === Backend variables for faster test execution
 
-The +os-autoinst+ backend offers multiple test variables which are helpful for
+The `os-autoinst` backend offers multiple test variables which are helpful for
 test development. For example:
 
-* Set +_EXIT_AFTER_SCHEDULE=1+ if you only want to evaluate the test schedule
+* Set `_EXIT_AFTER_SCHEDULE=1` if you only want to evaluate the test schedule
   before the test modules are executed
 
-* Use +_SKIP_POST_FAIL_HOOKS=1+ to prevent lengthy post_fail_hook execution in
+* Use `_SKIP_POST_FAIL_HOOKS=1` to prevent lengthy post_fail_hook execution in
   case of expected and known test fails, for examples when you need to create
   needles anyway
 
@@ -1243,7 +1243,7 @@ which can help in this situation.
 
 Depending on the use case, there are two options to help:
 
-* Create and *preserve* snapshots for *every test* module run (+MAKETESTSNAPSHOTS+)
+* Create and *preserve* snapshots for *every test* module run (`MAKETESTSNAPSHOTS`)
   - Offers more flexibility as the test can be resumed almost at any point.
     However disk space requirements are high (expect more than 30GB for one
     job).
@@ -1251,15 +1251,15 @@ Depending on the use case, there are two options to help:
     as more than just the snapshot of the last failed module is saved.
 
 * Create a snapshot *after every successful* test module while *always
-  overwriting* the existing snapshot to preserve only the latest (+TESTDEBUG+)
+  overwriting* the existing snapshot to preserve only the latest (`TESTDEBUG`)
   - Allows to skip just before the start of the first failed test module,
     which can be limiting, but preserves disk space in comparison to
-    +MAKETESTSNAPSHOTS+.
+    `MAKETESTSNAPSHOTS`.
   - This mode is useful for iterative test development
 
-In both modes there is no need to modify tests (i.e. adding +milestone+ test
+In both modes there is no need to modify tests (i.e. adding `milestone` test
 flag as the behaviour is implied). In the later mode every test module is
-also considered +fatal+. This means the job is aborted after the first failed
+also considered `fatal`. This means the job is aborted after the first failed
 test module.
 
 ==== Enable snapshots for each module
@@ -1267,7 +1267,7 @@ test module.
 * Run the worker with --no-cleanup parameter. This will preserve the hard
  disks after test runs.
 
-* Set +MAKETESTSNAPSHOTS=1+ on a job. This will make openQA save a
+* Set `MAKETESTSNAPSHOTS=1` on a job. This will make openQA save a
 snapshot for every test module run. One way to do that is by cloning an
 existing job and adding the setting:
 
@@ -1276,8 +1276,8 @@ existing job and adding the setting:
 openqa-clone-job --from https://openqa.opensuse.org  --host localhost 24 MAKETESTSNAPSHOTS=1
 ----
 
-* Create a job again, this time setting the +SKIPTO+ variable to the snapshot
-* you need. Again, +openqa-clone-job+ comes handy here:
+* Create a job again, this time setting the `SKIPTO` variable to the snapshot
+* you need. Again, `openqa-clone-job` comes handy here:
 
 [source,sh]
 ----
@@ -1289,8 +1289,8 @@ openqa-clone-job --from https://openqa.opensuse.org  --host localhost 24 SKIPTO=
 
 ==== Storing only the last sucessful snapshot
 
-* Run the worker with +--no-cleanup parameter+. This will preserve the hard disks after test runs.
-* Set +TESTDEBUG=1+ on a job. This will make openQA save a snapshot after each
+* Run the worker with `--no-cleanup parameter`. This will preserve the hard disks after test runs.
+* Set `TESTDEBUG=1` on a job. This will make openQA save a snapshot after each
 successful test module run. Snapshots are overwritten. The snapshot is named `lastgood` in all cases.
 
 [source,sh]
@@ -1298,9 +1298,9 @@ successful test module run. Snapshots are overwritten. The snapshot is named `la
 openqa-clone-job --from https://openqa.opensuse.org  --host localhost 24 TESTDEBUG=1
 ----
 
-* Create a job again, this time setting the +SKIPTO+ variable to the snapshot
+* Create a job again, this time setting the `SKIPTO` variable to the snapshot
 which failed on previous run. Make sure the new job will also have
-+TESTDEBUG=1+ set. This can be ensured by the use of the clone_job script on
+`TESTDEBUG=1` set. This can be ensured by the use of the clone_job script on
 the clone source job or specifying the variable explicitly:
 
 [source,sh]
@@ -1311,10 +1311,10 @@ openqa-clone-job --from https://openqa.opensuse.org  --host localhost 24 TESTDEB
 === Defining a custom test schedule or custom test modules
 
 Normally the test schedule, that is which test modules should be executed and
-which order, is prescribed by the +main.pm+ file within the test distribution.
+which order, is prescribed by the `main.pm` file within the test distribution.
 Additionally it is possible to exclude certain test modules from execution
-using the os-autoinst test variables +INCLUDE_MODULES+ and +EXCLUDE_MODULES+ as
-well as define a custom schedule using the test variable +SCHEDULE+.
+using the os-autoinst test variables `INCLUDE_MODULES` and `EXCLUDE_MODULES` as
+well as define a custom schedule using the test variable `SCHEDULE`.
 Also test modules can be defined and overridden on-the-fly using a
 downloadable asset.
 
@@ -1362,7 +1362,7 @@ NOTE: Including modules that are not scheduled does not raise an error, but they
 
 ==== SCHEDULE
 
-Additionally it is possible to define a custom schedule using the test variable +SCHEDULE+.
+Additionally it is possible to define a custom schedule using the test variable `SCHEDULE`.
 
 ----
 openqa-clone-job --from https://openqa.opensuse.org --host https://openqa.opensuse.org 24 SCHEDULE=tests/boot/boot_to_desktop,tests/console/consoletest_setup
@@ -1405,7 +1405,7 @@ sub post_run_hook {}
 For example this can be used in bug investigations or trying out new test
 modules which are hard to test locally.
 https://github.com/os-autoinst/os-autoinst/blob/master/doc/backend_vars.asciidoc
-describes the +SCHEDULE+ parameter in details as well as the others. The
+describes the `SCHEDULE` parameter in details as well as the others. The
 section "Asset handling" in the <<UsersGuide.asciidoc#usersguide,Users Guide>>
 describes how downloadable assets can be specified. It is important to note
 that the specified asset is only downloaded once. New versions must be
@@ -1418,13 +1418,13 @@ request on github or any branch or git refspec. That means that code changes
 that are not yet available on a production instance of openQA can be tested
 safely to ensure the code changes work as expected before merging the code
 intro a production repository and branch. This works by setting the
-+CASEDIR+ parameter of os-autoinst to a valid git repository path including
+`CASEDIR` parameter of os-autoinst to a valid git repository path including
 an optional branch/refspec specifier.
 See
 https://github.com/os-autoinst/os-autoinst/blob/master/doc/backend_vars.asciidoc
 for details.
 
-A helper script +openqa-clone-custom-git-refspec+ is available for
+A helper script `openqa-clone-custom-git-refspec` is available for
 convenience that supports some combinations.
 
 To clone one job within a remote instance based on an open github pull request
@@ -1440,8 +1440,8 @@ For example:
 openqa-clone-custom-git-refspec https://github.com/os-autoinst/os-autoinst-distri-opensuse/pull/6649 https://openqa.opensuse.org/tests/839191
 ----
 
-Keep in mind that if +PRODUCTDIR+ is overwritten it might not relate to the
+Keep in mind that if `PRODUCTDIR` is overwritten it might not relate to the
 state of the specified git refspec. For example the asset caching
-functionality will override the +PRODUCTDIR+ variable. The above method can
+functionality will override the `PRODUCTDIR` variable. The above method can
 still be used in this case in the common case that the test schedule does not
-need to be changed or in case a custom schedule is defined by +SCHEDULE+.
+need to be changed or in case a custom schedule is defined by `SCHEDULE`.


### PR DESCRIPTION
- Highlighting important information to make it more visible to the user.
- Marked up systemctl start worker command. 